### PR TITLE
Fix jenkins job to sync Mobile's develop branch

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -438,9 +438,10 @@ def runAllTestClients() {
                 _setupWebapp();
                 // We also need to sync mobile, so we can run
                 // content/end_to_end/android_integration_smoketest.py.
+                // Note that Mobile latest code is at develop branch
                 // TODO(benkraft): Do this in runmsoketests.py instead
                 // (at need), or in the smoketest itself?
-                kaGit.safeSyncToOrigin("git@github.com:Khan/mobile", "master");
+                kaGit.safeSyncToOrigin("git@github.com:Khan/mobile", "develop");
                 // We can go no further until we know the server to connect to.
                 waitUntil({ TEST_SERVER_URL != null });
                 runTestWorker(workerId);

--- a/jobs/firstinqueue-priming.groovy
+++ b/jobs/firstinqueue-priming.groovy
@@ -101,8 +101,9 @@ def prime() {
    _setupWebapp();
    // We also need to sync mobile, so we can run the mobile integration test
    // (if we are assigned to do so).
+   // Note that Mobile latest code is at develop branch
    // TODO(benkraft): Only run this if we get it from the splits?
-   kaGit.safeSyncToOrigin("git@github.com:Khan/mobile", "master");
+   kaGit.safeSyncToOrigin("git@github.com:Khan/mobile", "develop");
 }
 
 def primeWorkers() {


### PR DESCRIPTION
## Summary:
Mobile now use the `develop` branch as their latest code.
Let's update our test to reflect that.

Issue: https://khanacademy.slack.com/archives/CT1CYDM3N/p1619210697012800

## Test plan:

[Deploy](https://github.com/Khan/jenkins-jobs#deploy) (i.e. merge!), and rerun failed test.  Confirm that new code from mobile repo
is picked up.