### PR TITLE
INFRA-6777 - Update testing jobs to pass if when there are no tests

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -294,14 +294,17 @@ def runTestServer() {
       }
 
       // Determine if we actually need to run any tests at all
-      // tests = sh(script: "testing/runtests_server.py -n ${exec.shellEscapeList(runSmokeTestsArgs)} . ", returnStdout: true);
-      tests = exec.outputOf(["testing/runtests_server.py", "-n", runSmokeTestsArgs, "."].flatten());
+      // TODO(dbraley): This process takes a few seconds to run, and is done 
+      //  again by the actual server run a bit later in this method. We should
+      //  make this faster, or at least able to reuse the test list we've 
+      //  already calculated.
+      tests = exec.outputOf(["testing/runtests_server.py", "-n"] + runSmokeTestsArgs + ["."]);
 
       // The runtests_server.py script with -n outputs all tests to run of 
       // various types. We only need to worry about smoke tests, which are 
       // also the last section, so grab everything after the header. If it's 
       // empty, there are no tests to run.
-      e2eTests = tests.substring(tests.lastIndexOf("SMOKE TESTS:") + 12)
+      e2eTests = tests.substring(tests.lastIndexOf("SMOKE TESTS:") + "SMOKE TESTS:".length())
       // An empty line indicates the end of the section (if found)
       emptyLineIndex = e2eTests.lastIndexOf('\n\n')
       if (emptyLineIndex >= 0) {

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -262,6 +262,14 @@ def runTestServer() {
                           "--lintfile=../files_to_lint.txt",
                         ];
 
+      // Determine if we actually need to run any tests at all
+      tests = exec.outputOf(["cat", "../files_to_test.txt"]);
+      if (tests.isAllWhitespace()) {
+         echo("No Unit Tests to run!")
+         skipTestAnalysis = true
+         throw new TestsAreDone();
+      }
+
       // This gets our 10.x.x.x IP address.
       def serverIP = exec.outputOf(["ip", "route", "get", "10.1.1.1"]).split()[6];
       // This unblocks the test-workers to let them know they can connect
@@ -279,13 +287,6 @@ def runTestServer() {
       // runtests_server.py writes to this directory.  Make sure it's clean
       // before it does so, so it doesn't read "old" data.
       sh("rm -rf genfiles/test-reports");
-
-      tests = sh(script: "cat ../files_to_test.txt", returnStdout: true);
-      if (tests.isAllWhitespace()) {
-         echo("No Unit Tests to run!")
-         skipTestAnalysis = true
-         return
-      }
 
       // START THE SERVER!  Note this blocks.  It will auto-exit when
       // it's done serving all the tests.


### PR DESCRIPTION
All of our testing jobs end with a required analysis phase. Unfortunately analysis fails if there are no testing reports to analyze. This can be a good thing, since there are legitimately times where test reports might fail to be generated or saved, which should cause the job to fail. However, there are other times we have entered the testing phase, but have no tests to run - either they've been marked as already run elsewhere in the case of e2e tests, or there are just no tests to run for whatever has changed in the case of unit tests. In these scenarios, there are no test reports generated, and that fails analysis, when in reality there is no problem and the stage should complete correctly.

Here we detect this prior to running the tests, then set a variable to let our analysis phase later know that it can be skipped as it will not find any reports, thus passing the testing job (assuming there was no other failure in the interim).

# Test Plan:
## Unit Tests
1. See [webapp-test-113728](https://jenkins.khanacademy.org/job/deploy/job/webapp-test/113728/consoleText), a webapp test job that was run with the code here* that had multiple unit tests to run, and does correctly report that it enters and completes the `Analyzing results` stage, and that the job completes successfully.
2. See [webapp-test-113727](https://jenkins.khanacademy.org/job/deploy/job/webapp-test/113727/consoleText), a webapp test job that was run with the code here* that had zero unit tests to run, and logs at the end of the run that it is `Skipping Analysis - No tests run`. The job completed successfully.
3. To run this yourself, create a branch with a file deleted, such as a local dev script (or use [this](https://github.com/khan/webapp/tree/INFRA-6777-dummy-webapp-branch) branch). Have sun run the test job on the branch. If prior to merging of this code, rerun the job with this branches `webapp-test.groovy`, as outlined [here](https://khanacademy.atlassian.net/wiki/spaces/INFRA/pages/546931008/Introduction+to+Jenkins+Administration#Test-by-Replay). Observe the test passes.

## E2E Tests
1. See [e2e-test 31199](https://jenkins.khanacademy.org/job/deploy/job/e2e-test/31199/consoleText), an end to end test job run with the code here* that had one e2e test to run, and does correct log at the end of the file that it enters and completes the `Analyzing results` stage, and that the job completes successfully.
2. See [e2e-test 31202](https://jenkins.khanacademy.org/job/deploy/job/e2e-test/31202/consoleText), an end to end test job run with the code here* that had no e2e tests to run, and logs at the end of the run that it is `Skipping Analysis - No tests run`. The job completed successfully.
3. To run this yourself, find any run of the e2e tests, the click rebuild and modify the `TESTS_TO_RUN` field and the `SKIP_TESTS` fields to have the same value of a valid test (technically, you can include more skip tests, but it’s not necessary). For the sake of not being a nuisance, you should point the slack channel at your slack name or some other low traffic channel, clear the slack thread, lower the number of workers (and make sure they’re not first-in-queue), and rename the test to something that indicates what you’re doing. Then run that, and you’ll observe the tail of the log indicates `ERROR: None of the test reports contained any result`. Then click **Replay** and replace the code with this version of the `e2e-test.groovy` and notice that the run passes by skipping the analysis phase.
