### PR TITLE
[🔥AUDIT🔥] Let make-allcheck run on more machines.

### DIFF
--- a/jobs/make-allcheck.groovy
+++ b/jobs/make-allcheck.groovy
@@ -38,12 +38,8 @@ def runAllTests() {
              string(name: 'MAX_SIZE', value: "huge"),
              string(name: 'SLACK_CHANNEL', value: "#1s-and-0s"),
              booleanParam(name: 'FORCE', value: params.FORCE),
-            // The single test make_test_db_test takes 99 minutes to
-            // run.  All the other tests between them take 340 minutes
-            // to run.  So 5 other CPUs is right to have everyone
-            // finish after ~99 minutes.
-            string(name: 'NUM_WORKER_MACHINES', value: "3"),
-            string(name: 'CLIENTS_PER_WORKER', value: "2"),
+             string(name: 'NUM_WORKER_MACHINES', value: "6"),
+             string(name: 'CLIENTS_PER_WORKER', value: "2"),
           ]);
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The make-allcheck rule hasn't been posting to slack for the last
week.  Looking into it, it's because the tests are timing out after 2
hours, which is before they finish running.

I don't know why tests are taking so long now.  Maybe we just have
more of them?  Still, I wouldn't expect all our Go tests to take
longer than all our python tests did.  In any case, I'll just
parallelize `make allcheck` a bit more so it can finish within 2 hours
again.

Issue: none

## Test plan:
Figners crossed