### PR TITLE
Exclude _manifest.json from being cleaned up

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -252,11 +252,14 @@ clean_ka_static() {
     # continue to point to them. Thankfully, they don't change that often, and
     # so we shouldn't expect an explosion of stale icons. We don't need to
     # worry about keeping older manifests around, since the mobile clients
-    # download and ship with the most recent manifest.
+    # download and ship with the most recent manifest.  We keep _manifest.json
+    # around since it's used by the static deploy process to reduce the number
+    # of files we need to upload to GCS (it contains a list of files that were
+    # uploaded during the last static deploy).
     # We also need to keep around CKEditor, live-editor, and MathJax as we
     # treat them as a static asset at this point. More information:
     # https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/1257046459/Static+JS+Third+Party+Library+Files
-    KA_STATIC_WHITELIST="-e genfiles/topic-icons/icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/"
+    KA_STATIC_WHITELIST="-e genfiles/topic-icons/icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/ -e _manifest.json"
 
     # Now we go through every file in ka-static and delete it if it's
     # not in files-to-keep.  We ignore lines ending with ':' -- those

--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -259,7 +259,7 @@ clean_ka_static() {
     # We also need to keep around CKEditor, live-editor, and MathJax as we
     # treat them as a static asset at this point. More information:
     # https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/1257046459/Static+JS+Third+Party+Library+Files
-    KA_STATIC_WHITELIST="-e genfiles/topic-icons/icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/ -e _manifest.json"
+    KA_STATIC_WHITELIST="-e genfiles/topic-icons/icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/ -e /_manifest.json"
 
     # Now we go through every file in ka-static and delete it if it's
     # not in files-to-keep.  We ignore lines ending with ':' -- those


### PR DESCRIPTION
## Summary:
Earlier in the week people were experience an in issue with static deploys failing because of 503s.  While investigating the issue I noticed that _manifest.json was no longer in gs://ka-static.  This PR should fix that issue.  I've already deployed a separate webapp PR that manually retries (up to three times) if we encounter any 503s when uploading files to GCS as part of the static deploy process.

Issue: none

## Test plan:
```
KA_STATIC_WHITELIST="-e genfiles/topic-icons/icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/ -e /_manifest.json"
gsutil -m ls -r gs://ka-static/ \
        | grep . \
        | grep -v ':$' \
        | grep -v `echo $KA_STATIC_WHITELIST`
```

See the following output:
```
gs://ka-static/_manifest..json
gs://ka-static/_manifest.180201-1131-a47ef9506805.json
gs://ka-static/_manifest.210907-1015-c8691d9adccf.json
gs://ka-static/_manifest.211006-1425-a5db6826dfdc.json
gs://ka-static/_manifest.211007-0601-43fd914caa83.json
gs://ka-static/_manifest.211007-1042-a39907095643.json
gs://ka-static/_manifest.211007-1238-deb53fbc4adb.json
gs://ka-static/_manifest.211011-1107-e9f13a5b63ff.json
gs://ka-static/_manifest.211011-1129-1616428d2bef.json
gs://ka-static/_manifest.211011-1129-ff545538bd9c.json
gs://ka-static/_manifest.211011-1141-94c501f0e6a9.json
gs://ka-static/_manifest.211011-1149-616568a8776d.json
gs://ka-static/_manifest.211011-1308-7876e94c912f.json
gs://ka-static/_manifest.211011-1319-af20268ac21b.json
gs://ka-static/_manifest.211011-1319-c0366778c699.json
gs://ka-static/_manifest.211011-1335-6250f2a4de99.json
gs://ka-static/_manifest.211011-1335-8b55e7fdcc4b.json
gs://ka-static/_manifest.211011-1351-43b01886b94a.json
gs://ka-static/_manifest.211011-1548-732eccc5fda3.json
gs://ka-static/_manifest.211011-1719-f7a55f5ccb29.json
gs://ka-static/_manifest.211011-1759-976a6be8bcb0.json
gs://ka-static/_manifest.211012-0306-149cab35f5fd.json
gs://ka-static/_manifest.211012-0610-847cc02c4579.json
gs://ka-static/_manifest.211012-0628-a02c15b03907.json
gs://ka-static/_manifest.211012-0631-9012a54deae2.json
gs://ka-static/_manifest.211012-0852-cfd92da134f0.json
gs://ka-static/_manifest.211012-0855-d7753ffba4d5.json
gs://ka-static/_manifest.211012-1004-0696332a0194.json
gs://ka-static/_manifest.211012-1113-df2026a26634.json
gs://ka-static/_manifest.211012-1114-5088b2c0bd49.json
gs://ka-static/_manifest.211012-1117-656c7f806821.json
gs://ka-static/_manifest.211012-1118-41410c56bb8d.json
gs://ka-static/_manifest.211012-1140-ae48f014ef91.json
gs://ka-static/_manifest.211012-1208-3ecfb42d0e73.json
gs://ka-static/_manifest.211012-1246-2ba40aa7a25b.json
gs://ka-static/_manifest.211012-1246-cab3ca59dc24.json
gs://ka-static/_manifest.211012-1319-6d950e7507fb.json
gs://ka-static/_manifest.211012-1319-f4660bf4bbef.json
gs://ka-static/_manifest.211012-1602-a2deda3d5aad.json
gs://ka-static/_manifest.211012-1603-84c0d1badeac.json
gs://ka-static/_manifest.211013-0441-50151fc445e4.json
gs://ka-static/_manifest.211013-0657-e01a4ecbef20.json
gs://ka-static/_manifest.211013-0711-fe04a3a7b6c8.json
gs://ka-static/_manifest.211013-0712-3b53a99daafe.json
gs://ka-static/_manifest.211013-0822-1735ba1174b2.json
gs://ka-static/_manifest.211013-0826-a87db59917aa.json
gs://ka-static/_manifest.211013-1355-0b9610c665a2.json
gs://ka-static/_manifest.211013-1355-a6dc7e6de0d9.json
gs://ka-static/_manifest.211013-1401-9ef95a850677.json
gs://ka-static/_manifest.211013-1407-90f1105ba7be.json
gs://ka-static/_manifest.211013-1408-0d70c3eed420.json
gs://ka-static/_manifest.211013-1408-4ecd4c4ead25.json
gs://ka-static/_manifest.211013-1412-4d4c1c79275e.json
gs://ka-static/_manifest.211013-1426-e2851109ae0b.json
gs://ka-static/_manifest.211013-1426-f612c5f5ef38.json
gs://ka-static/_manifest.znd-210915-jeanette-j.json
gs://ka-static/_manifest.znd-210915-nickbree-1.json
gs://ka-static/_manifest.znd-210916-jeff-v1.json
gs://ka-static/_manifest.znd-210916-kevinb-1.json
gs://ka-static/_manifest.znd-210916-russell-r1.json
gs://ka-static/_manifest.znd-210916-tonydinh-1.json
gs://ka-static/_manifest.znd-210917-adam-multi.json
gs://ka-static/_manifest.znd-210917-briangen-bga.json
gs://ka-static/_manifest.znd-210917-kevinb-1.json
gs://ka-static/_manifest.znd-210920-boris-r2.json
gs://ka-static/_manifest.znd-210920-briangen-bga.json
gs://ka-static/_manifest.znd-210920-briangen-pub.json
gs://ka-static/_manifest.znd-210920-jeff-v1.json
gs://ka-static/_manifest.znd-210920-kevinb-1.json
gs://ka-static/_manifest.znd-210920-kevinb-2.json
gs://ka-static/_manifest.znd-210920-kevinb-3.json
gs://ka-static/_manifest.znd-210920-nickbree-10.json
gs://ka-static/_manifest.znd-210921-briangen-bgb.json
gs://ka-static/_manifest.znd-210921-kevinb-1.json
gs://ka-static/_manifest.znd-210921-kevinb-2.json
gs://ka-static/_manifest.znd-210921-mahtab-cp5607.json
gs://ka-static/_manifest.znd-210922-aasmund-dtp.json
gs://ka-static/_manifest.znd-210922-adamgofo-1.json
gs://ka-static/_manifest.znd-210922-emilyjan-1.json
gs://ka-static/_manifest.znd-210922-leith-pr1456.json
gs://ka-static/_manifest.znd-210922-leith-pr1465.json
gs://ka-static/_manifest.znd-210922-nickbree-11.json
gs://ka-static/_manifest.znd-210923-samuelta-1.json
gs://ka-static/_manifest.znd-210927-angelo-a2.json
gs://ka-static/_manifest.znd-210927-angelo-a4.json
gs://ka-static/_manifest.znd-210927-jordanos-jo1.json
gs://ka-static/_manifest.znd-210927-nickbree-12.json
gs://ka-static/_manifest.znd-210928-angelo-a5.json
gs://ka-static/_manifest.znd-210928-michaelm-qe1.json
gs://ka-static/_manifest.znd-210929-jeremy-mv-2.json
gs://ka-static/_manifest.znd-210929-jeremy-mv.json
gs://ka-static/_manifest.znd-211001-alanszlo-alan.json
gs://ka-static/_manifest.znd-211001-angelo-l1.json
gs://ka-static/_manifest.znd-211001-kevinb-1.json
gs://ka-static/_manifest.znd-211004-nickbree-15.json
gs://ka-static/_manifest.znd-211004-salmanom-1.json
gs://ka-static/_manifest.znd-211004-salmanom-2.json
gs://ka-static/_manifest.znd-211004-salmanom-3.json
gs://ka-static/_manifest.znd-211005-pepper-at.json
gs://ka-static/_manifest.znd-211006-briangen-bga.json
gs://ka-static/_manifest.znd-211007-emilyjan-1.json
gs://ka-static/_manifest.znd-211008-salmanom-1.json
gs://ka-static/_manifest.znd-211011-emilyjan-1.json
gs://ka-static/_manifest.znd-211011-jeanette-jh.json
gs://ka-static/_manifest.znd-211011-kevinb-1.json
gs://ka-static/_manifest.znd-211012-jared-a.json
gs://ka-static/_manifest.znd-211012-salmanom-1.json
gs://ka-static/_manifest.znd-211013-kevinb-1.json
gs://ka-static/apple-app-site-association
gs://ka-static/check-access-third-party-cookie-test.html
gs://ka-static/favicon.ico
gs://ka-static/google663128d2a1a65b87.html
gs://ka-static/google792d5af4cf2b43d6.html
gs://ka-static/pinterest-9442e.html
...
```

See that `/_manifest.json` is not present in the output.

The reason for using `echo $KA_STATIC_WHITELIST` inside backticks is that `zsh` doesn't auto-split strings when assigning variables and so it was passing the whole string as a single arg.