### PR TITLE
Don't remove topic-icons/icon-manifest.json

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -259,7 +259,7 @@ clean_ka_static() {
     # We also need to keep around CKEditor, live-editor, and MathJax as we
     # treat them as a static asset at this point. More information:
     # https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/1257046459/Static+JS+Third+Party+Library+Files
-    KA_STATIC_WHITELIST="-e genfiles/topic-icons/icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/ -e /_manifest.json"
+    KA_STATIC_WHITELIST="-e genfiles/topic-icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/ -e /_manifest.json"
 
     # Now we go through every file in ka-static and delete it if it's
     # not in files-to-keep.  We ignore lines ending with ':' -- those


### PR DESCRIPTION
## Summary:
Now that we aren't uploading this file with every static deploy, we don't want topic-icons/icon-manifest.json to be removed as part of the weekly cleanup.

Issue: none

## Test plan:
```
KA_STATIC_WHITELIST="-e genfiles/topic-icons/ -e ckeditor/ -e live-editor/ -e khan-mathjax-build/ -e /_manifest.json" 
gsutil -m ls -r gs://ka-static/ \
        | grep . \
        | grep -v ':$' \
        | grep -v `echo $KA_STATIC_WHITELIST`
```

See that the output doesn't include genfiles/topic-icons/:
```
...
gs://ka-static/genfiles/stylesheets_for_debugging/he/video-lite-package-94161c.css
gs://ka-static/genfiles/stylesheets_for_debugging/he/video-package-5abb45.css
gs://ka-static/genfiles/stylesheets_for_debugging/he/zero-rating-package-a30283.css
gs://ka-static/genwebpack/manifests/toc-webpack-manifest-211020-1137-98f76e5292d9.json
gs://ka-static/genwebpack/manifests/toc-webpack-manifest-211020-1233-a7a7479434b6.json
gs://ka-static/genwebpack/manifests/toc-webpack-manifest-211020-1406-3e3522564e9b.json
...
```