### PR TITLE
[🔥AUDIT🔥] Log the appserver log when the devshell script fails.

### DIFF
--- a/build_current_sqlite.sh
+++ b/build_current_sqlite.sh
@@ -49,6 +49,8 @@ for snapshot_bucket in $SNAPSHOT_NAMES; do
         ./app.yaml > genfiles/appserver.log 2>&1 &
     appserver_pid=$!
 
+    trap 'tail -n100 genfiles/appserver.log' 0 HUP INT QUIT
+
     # wait for server to start
     sleep 60
 
@@ -76,6 +78,8 @@ for snapshot_bucket in $SNAPSHOT_NAMES; do
     # fully written current.sqlite to disk
     sleep 30
     is_first_run=
+
+    trap - 0 HUP INT QUIT
 done
 
 cd ..


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This will hopefully give some clue as to why it's failing.

I am seeing this in the build_current_sqlite job run:
```
20:21:40  + timeout 10h python third_party/frankenserver/dev_appserver.py --application=khan-academy --datastore_path=../current.sqlite --port=9085 --require_indexes=yes --skip_sdk_update_check=yes --automatic_restart=no --admin_port=0 --max_module_instances=1 --log_level=info --host=127.0.0.1 ./app.yaml
20:22:48  + echo snapshot_es
20:22:48  + awk -F_ {print $NF}
20:22:48  + locale_name=es
20:22:48  + tools/devshell.py --host localhost:9085 --script dev/dev_appserver/run_sync.py ../snapshot_es es
20:22:48  Could not connect to localhost:9085. Is it running?
```
I have no idea why the dev-appserver isn't starting up (or maybe it is
and we just need to wait longer?) -- the logging will hopefully give
some clues.

Issue: https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1127/console

## Test plan:
Will try running it and see!