### PR TITLE
[🔥AUDIT🔥] Explicitly kill dev-server subprocesses as well as dev-server.

### DIFF
--- a/build_current_sqlite.sh
+++ b/build_current_sqlite.sh
@@ -74,6 +74,12 @@ for snapshot_bucket in $SNAPSHOT_NAMES; do
         sleep 10
     fi
 
+    # make sure dev-server's subprocesses are stopped too.
+    # 8011 is the pubsub emulator; 8081 is the nginx proxy.
+    lsof -t -iTCP:8011 -iTCP:8081 | xargs kill -15
+    sleep 10
+    lsof -t -iTCP:8011 -iTCP:8081 | xargs kill -9
+
     # wait some extra time to make sure everything has actually shut down and
     # fully written current.sqlite to disk
     sleep 30


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We are seeing the build-sqlite job fail with the following log message
after finishing the english run and starting the spanish run:
```
RuntimeError: Port 8011 is in use, but not by pubsub-emulator like is
needed
```

This indicates to me that the pubsub emulator was not properly shut
down (like it's hanging or something).  Adding a few kill commands
should help with that.

Issue: XXX-XXXX

## Test plan:
Ran
    python third_party/frankenserver/dev_apprver.py --application=khan-academy --datastore_path=../current.sqlite --port=9085 --require_indexes=yes --skip_sdk_update_check=yes --automatic_restart=no --admin_port=0 --max_module_instances=1 --log_level=info --host=127.0.0.1 ./app.yaml &
    lsof -t -iTCP:8012 -o -iTCP:8081 -iTCP:8011 | xargs kill -15
and then did
    ps xfww
and saw that the pubsub-emulator isn't running anymore.