### PR TITLE
[🔥AUDIT🔥] Use `xargs -r` to make sure we don't run it if we don't need to.

### DIFF
--- a/build_current_sqlite.sh
+++ b/build_current_sqlite.sh
@@ -76,9 +76,9 @@ for snapshot_bucket in $SNAPSHOT_NAMES; do
 
     # make sure dev-server's subprocesses are stopped too.
     # 8011 is the pubsub emulator; 8081 is the nginx proxy.
-    lsof -t -iTCP:8011 -iTCP:8081 | xargs kill -15
+    lsof -t -iTCP:8011 -iTCP:8081 | xargs -r kill -15
     sleep 10
-    lsof -t -iTCP:8011 -iTCP:8081 | xargs kill -9
+    lsof -t -iTCP:8011 -iTCP:8081 | xargs -r kill -9
 
     # wait some extra time to make sure everything has actually shut down and
     # fully written current.sqlite to disk


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In my local (ubuntu) testing, `kill -15` with no other args doesn't
give an error.  But it does on jenkins, so add the `-r`.

`xargs -r` isn't supported on os x, but I don't think that's a concern
for jenkins jobs, which are never going to run on a mac.

Issue: XXX-XXXX

## Test plan:
Will run on jenkins