### PR TITLE
[🔥AUDIT🔥] Concat our urls so they only have one `/`, not two.

### DIFF
--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -93,10 +93,10 @@ def _dataForAlertlib(status, extraText) {
    // bugtracker, we don't want to open a new task for each failure)
    def subject = "${env.JOB_NAME} ${_statusText(status, false)}";
    def severity = "info";
-   def body = "${subject}: See ${env.BUILD_URL}/ for full details.\n";
+   def body = "${subject}: See ${env.BUILD_URL} for full details.\n";
    if (_failed(status)) {
       severity = "error";
-      body = ("${subject}: See ${env.BUILD_URL}/flowGraphTable/ " +
+      body = ("${subject}: See ${env.BUILD_URL}flowGraphTable/ " +
               "for what failed (look for the red circle(s)).\n")
    }
    if (extraText) {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
BUILD_URL ends with a slash, so adding a slash like I was doing
yielded urls like:
  https://jenkins.khanacademy.org/job/deploy/job/deploy-internal-services/50//
Now there's just one `/` at the end.

Both urls work, at least in chrome, so this is really just cosmetic.

Issue: https://khanacademy.slack.com/archives/C8Y4Q1E0J/p1637687766119700

## Test plan:
Fingers crossed