### PR TITLE
Upload the go-style gateway config to gcs when we upload the js-style one.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -460,6 +460,11 @@ def deployToGatewayConfig() {
        exec(["make", "-C", "services/graphql-gateway",
              "deploy-gateway-config",
              "DEPLOY_VERSION=${NEW_VERSION}"]);
+       if (fileExists("services/graphql-gateway-2/Makefile")) {
+          exec(["make", "-C", "services/graphql-gateway-2",
+                "deploy-gateway-config",
+                "DEPLOY_VERSION=${NEW_VERSION}"]);
+       }
    }
 }
 

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -288,6 +288,11 @@ def deployToGatewayConfig() {
        exec(["make", "-C", "services/graphql-gateway",
              "deploy-gateway-config",
              "DEPLOY_VERSION=${VERSION}"]);
+       if (fileExists("services/graphql-gateway-2/Makefile")) {
+          exec(["make", "-C", "services/graphql-gateway-2",
+                "deploy-gateway-config",
+                "DEPLOY_VERSION=${VERSION}"]);
+       }
    }
 }
 


### PR DESCRIPTION
## Summary:
graphql-gateway-2 (aka go-go-graphql-gateway) uses a different style
of config file than graphql-gateway (aka apollo).  We need to upload
them both.

I protect this upload in an "if exists" check so things don't suddenly
start to break when we move to only having one go gateway again.

Issue: https://khanacademy.atlassian.net/browse/INFRA-7074

## Test plan:
groovy jobs/build-webapp.groovy
groovy jobs/deploy-znd.groovy