### PR TITLE
Notify in the fastly slack channel how to roll back on error.

### DIFF
--- a/jobs/deploy-fastly.groovy
+++ b/jobs/deploy-fastly.groovy
@@ -83,11 +83,11 @@ def installDeps() {
    }
 }
 
-def _currentVersion() {
+def _activeVersion() {
    def cmd = [
        "make",
        "-C", "webapp/services/fastly-khanacademy",
-        params.TARGET == "prod" ? "current-version" : "current-version-test",
+        params.TARGET == "prod" ? "active-version" : "active-version-test",
    ];
    withTimeout('1m') {
       return exec.outputOf(cmd)
@@ -160,7 +160,7 @@ onMaster('30m') {
          installDeps();
       }
 
-      def oldActive = _currentVersion();
+      def oldActive = _activeVersion();
 
       stage("Deploying") {
          if (params.TARGET == "prod") {
@@ -176,7 +176,7 @@ onMaster('30m') {
          setDefault();
       }
 
-      def newActive = _currentVersion();
+      def newActive = _activeVersion();
       notifyWithVersionInfo(oldActive, newActive);
    }
 }

--- a/jobs/deploy-fastly.groovy
+++ b/jobs/deploy-fastly.groovy
@@ -86,6 +86,7 @@ def installDeps() {
 def _activeVersion() {
    def cmd = [
        "make",
+       "-s",
        "-C", "webapp/services/fastly-khanacademy",
         params.TARGET == "prod" ? "active-version" : "active-version-test",
    ];


### PR DESCRIPTION
## Summary:
When a fastly deploy goes wrong, it's a panic situation.  This PR
makes it easier to recover by always emitting, to the `#fastly` slack
channel, the sun command to run to undo the deploy.

Issue: https://github.com/Khan/internal-services/pull/71

## Test plan:
https://jenkins.khanacademy.org/job/deploy/job/deploy-fastly/1699

New output at
https://khanacademy.slack.com/archives/CCCC6HZ4K/p1643056437020100