### PR TITLE
Make some changes to try to get "build-current-sqlite" working again.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -65,7 +65,7 @@ def runScript() {
 
 
 // We run on a special worker machine because this job uses so much
-// memory.  
+// memory.
 onWorker("ka-content-sync-ec2", "8h") {
    notify([slack: [channel: '#infrastructure',
                    when: ['SUCCESS', 'FAILURE', 'ABORTED', 'UNSTABLE']]]) {


### PR DESCRIPTION
## Summary:
The main one is to wait longer for graphql-gateway to start up.  In my
local tests it can take over a minute.  I'm suspecting that is the
cause of these errors in the logs:

> 13:18:54  ERRO[0010] Post "http://localhost:8102/graphql/CreateUserModelsInOtherServices": dial tcp 127.0.0.1:8102: connect: connection refused

However I can't be sure because it's hard to tell what service is
outputting what logs.  I add some logic here to prepend every line of
log output with its service, to ease debugging.

I also found a typo involving redis-pid.

Issue: https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1216/console

## Test plan:
Fingers crossed -- will try running this again and see how it goes!