### PR TITLE
Ensure that rollback code is of the right version

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -802,7 +802,7 @@ def finishWithFailure(why) {
                // During the rollback, we need the local version of code to be
                // of the good version for some of the rollback operation
                // e.g. update dispatch.yaml
-               exec(["git", "checkout", "tag/${ROLLBACK_TO}"]);
+               exec(["git", "checkout", "tags/${ROLLBACK_TO}"]);
 
                // We use --bad-dict instead of --bad here because
                // there's no git tag yet for the bad version:

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -259,33 +259,33 @@ def _alert(def slackArgs, def interpolationArgs) {
    }
 }
 
-// This method filters a common 'DEPLOYER_USERNAME' into a series of comma 
-// seperated slack user id's for the purpose of passing into alert.py's 
+// This method filters a common 'DEPLOYER_USERNAME' into a series of comma
+// seperated slack user id's for the purpose of passing into alert.py's
 // '--slack' argument. For Example:
 // DEPLOYER_USERNAME: <@UMZGEUH09> (cc <@UN5UC0EM6>)
 // becomes: UMZGEUH09,UN5UC0EM6,
 // TODO(dbraley): Add parsing of `@` usernames and `#` channels if needed
 @NonCPS // for pattern & matcher
 def _userIdsFrom(def deployUsernameBlob) {
-   // Regex to specifically grab the ids, which should start with U and be 
-   // some number of capital letters and numbers. Ids can also start with 
+   // Regex to specifically grab the ids, which should start with U and be
+   // some number of capital letters and numbers. Ids can also start with
    // W (special users), T (teams), or C (channels).
     def pattern = /<@([UTWC][0-9A-Z]+)>/;
     def match = (deployUsernameBlob =~ pattern);
-    
+
     allUsers = "";
-    
+
     for (n in match) {
         allUsers += "${n[1]},";
     }
-    
+
     return allUsers;
 }
 
-// Sends a survey to the deployer and anyone cc'ed to help infrastructure 
-// understand why a deployment was aborted. Also sends it to 
+// Sends a survey to the deployer and anyone cc'ed to help infrastructure
+// understand why a deployment was aborted. Also sends it to
 // #dev-support-stream so we can follow up on 'missed' surveys.
-// 
+//
 // #infrastructure: <#C8Y4Q1E0J>
 def _sendAbortedDeploymentSurvey() {
     def msg = ":robot_hearthands: It looks like you recently aborted a " +
@@ -298,7 +298,7 @@ def _sendAbortedDeploymentSurvey() {
 
     def userIds = _userIdsFrom("${DEPLOYER_USERNAME}");
     userIds += "#dev-support-stream";
-   
+
     args = ["jenkins-jobs/alertlib/alert.py",
         "--slack=${userIds}",
         "--chat-sender=Mr Monkey",
@@ -799,6 +799,11 @@ def finishWithFailure(why) {
                  gitTag: GIT_TAG]);
          withSecrets() {
             dir("webapp") {
+               // During the rollback, we need the local version of code to be
+               // of the good version for some of the rollback operation
+               // e.g. update dispatch.yaml
+               exec(["git", "checkout", "tag/${ROLLBACK_TO}"]);
+
                // We use --bad-dict instead of --bad here because
                // there's no git tag yet for the bad version:
                // it's only created when we end a deploy with


### PR DESCRIPTION
## Summary:
During the rollback in our KRD [1] we noticed that we deploy a wrong
version of the dispatch.yaml. We can visibly see the traffic goes
to the new version of the graphql-gateway.

This is due to the local version of the code would still be on the
latest version, and some operations such as updating `dispatch.yaml`
will pick up the config from local code.

This diff ensure that we use
[1] https://jenkins.khanacademy.org/job/deploy/job/deploy-webapp/9990/

Issue: https://khanacademy.slack.com/archives/C8XGW76FQ/p1646079377461529

Test plan:

1. Merge this which should deploy this to jenkins
2. Create a fake deploy that have a harmless route redirection (e.g.
   redirecting a https://khan-academy.appspot.com/trace  to service-testbed)
3. Deploy, set-default and immediately force a rollback.
4. Validate that the dispatch route is not working after the rollback