### PR TITLE
Use the new graphql safelist-pruning script.

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -300,9 +300,9 @@ backup_network_config() {
 }
 
 
-# Delete unused queries from our GraphQL whitelist.
-clean_unused_queries() {
-    curl --retry 3 https://www.khanacademy.org/api/internal/graphql_safelist/clean
+# Delete unused queries from our GraphQL safelist.
+clean_unused_graphql_safelist_queries() {
+    ( cd webapp; tools/prune_graphql_safelist.sh --prod )
 }
 
 


### PR DESCRIPTION
## Summary:
The old one has been broken for months, maybe longer -- it times out.
I'm writing a new one in Go.  Let's start running it in our weekly
maintenance job; it can't do any worse than the old one!

Issue: https://khanacademy.atlassian.net/browse/INFRA-7672

## Test plan:
I ran this new script manually.:
```
% gcloud --project khan-internal-services compute ssh ubuntu@jenkins-server
$ sudo su - jenkins
$ cd ~/jobs/misc/jobs/webapp-maintenance/workspace/webapp
$ tools/prune_graphql_safelist.sh --prod
{"data":{"entitiesAfterPruning":"1916","entitiesBeforePruning":"1916","numDeletionErrors":"0"},"message":"Finished pruning, entitiesAfterPruning = 1916, entitiesBeforePruning = 1916, numDeletionErrors = 0","severity":"INFO"}
```

So it successfully ran.