### PR TITLE
[🔥AUDIT🔥] Upload the new supergraphql gateway config to gcs when we upload the old js one.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -475,6 +475,11 @@ def deployToGatewayConfig() {
        exec(["make", "-C", "services/graphql-gateway",
              "deploy-gateway-config",
              "DEPLOY_VERSION=${NEW_VERSION}"]);
+       if (fileExists("services/queryplanner/Makefile")) {
+          exec(["make", "-C", "services/queryplanner",
+                "deploy-gateway-config",
+                "DEPLOY_VERSION=${NEW_VERSION}"]);
+       }
    }
 }
 

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -288,6 +288,11 @@ def deployToGatewayConfig() {
        exec(["make", "-C", "services/graphql-gateway",
              "deploy-gateway-config",
              "DEPLOY_VERSION=${VERSION}"]);
+       if (fileExists("services/queryplanner/Makefile")) {
+          exec(["make", "-C", "services/queryplanner",
+                "deploy-gateway-config",
+                "DEPLOY_VERSION=${NEW_VERSION}"]);
+       }
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
queryplanner (the replacement for graphql-gateway) uses a different
style of config file -- the new supergraph format rather than the
csdl.  Until the replacement is copmlete, we need to upload them both.

I protect this upload in an "if exists" check so things don't break
for znd's or other old branches.

This is the analogue of #21, when we were using the go gateway configs.

Issue: https://khanacademy.atlassian.net/browse/INFRA-7637

## Test plan:
Fingers crossed