### PR TITLE
[🔥AUDIT🔥] Go a git clean after merging from master.

### DIFF
--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -39,6 +39,9 @@ def runScript() {
    kaGit.safeMergeFromMaster("webapp", params.GIT_BRANCH);
 
    dir("webapp") {
+      sh("timeout 2m git clean -ffd"); // in case the merge modified .gitignore
+      sh("timeout 1m git clean -ffd"); // sometimes we need two runs to clean
+
       sh("make clean_pyc");    // in case some .py files went away
       sh("make fix_deps");  // force a remake of all deps all the time
 

--- a/jobs/webapp-maintenance.groovy
+++ b/jobs/webapp-maintenance.groovy
@@ -33,6 +33,14 @@ def runScript() {
       // ...which we want to make sure is up-to-date with master.
       kaGit.safeMergeFromMaster("webapp", "automated-commits");
 
+      // Do some more cleaning in case the merge modified .gitignore.
+      // We run it twice because sometimes we need two runs to clean
+      // fully (if the first run deletes a .gitignore in a subrepo, say).
+      dir("webapp") {
+         sh("timeout 2m git clean -ffd");
+         sh("timeout 1m git clean -ffd");
+      }
+
       sh("jenkins-jobs/weekly-maintenance.sh");
    }
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
update-ownership-data failed last night because master had a change to
`.gitignore` in it, which caused some previously ignored files to be
un-ignored.  We didn't clean them up (that is, delete them) because
our cleaning happens in `safeSyncToOrigin`, which runs before the
merge from master.

To fix this, I just manually clean again after merging from master.
Only two scripts do a safeMergeFromMaster, so I didn't have to clean
up that many places.  (I thought of moving the `git clean`s to
safeMergeFromMaster itself, but I thought that wasn't safe because in
theory you could call merge-from-master at any time, including when
your workspace wasn't entirely clean, and I didn't want to do
destructive activities on something that sounds like it's only a merge
command.)

Issue: https://khanacademy.slack.com/archives/C3UDL9QN7/p1648116574142689

## Test plan:
Fingers crossed -- we'll see if tonight's update-ownership-data run succeeds.