### PR TITLE
[🔥AUDIT🔥] Remove graphql-gateway-2 from the list of required services.

### DIFF
--- a/build_current_sqlite.sh
+++ b/build_current_sqlite.sh
@@ -78,7 +78,7 @@ redis_pid=$!
 # list This list is ordered! some of these services are early in the
 # list because other services depend on them to start.
 # For example: grpc-translator and graphql-gateway
-required_services="grpc-translator localproxy queryplanner graphql-gateway graphql-gateway-2 admin analytics assignments campaigns coaches content content-editing content-library discussions districts donations emails progress rest-gateway rewards search test-prep users"
+required_services="grpc-translator localproxy queryplanner graphql-gateway admin analytics assignments campaigns coaches content content-editing content-library discussions districts donations emails progress rest-gateway rewards search test-prep users"
 
 # We also need to start the go services
 service_pids=


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Nothing in master users graphql-gateway-2 anymore, so we don't need to
start it up in this script.  Which is good, because soon that service
will be going away entirely!

Issue: https://khanacademy.atlassian.net/browse/INFRA-7739

## Test plan:
Fingers crossed -- we'll make sure build-current-sqlite succeeds tomorrow.