### PR TITLE
[🔥AUDIT🔥] Make sure the virtualenv comes before /usr/local/bin on $PATH.

### DIFF
--- a/vars/onWorker.groovy
+++ b/vars/onWorker.groovy
@@ -41,31 +41,31 @@ def call(def label, def timeoutString, Closure body) {
          // worker machines.
          dir("/home/ubuntu/webapp-workspace") {
             kaGit.checkoutJenkinsTools();
-            withVirtualenv() {
-               withTimeout(timeoutString) {
-                  // We document what machine we're running on, to help
-                  // with debugging.
-                  def instanceId = sh(
-                     script: ("curl -s " +
-                              "http://metadata.google.internal/computeMetadata/v1/instance/hostname " +
-                              "-H 'Metadata-Flavor: Google' | cut -d. -f1"),
-                     returnStdout: true).trim();
-                  def ip = exec.outputOf(
-                     ["curl", "-s",
-                      "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip",
-                      "-H", 'Metadata-Flavor: Google']);
-                  echo("Running on GCE instance ${instanceId} at ip ${ip}");
-                  // TODO(csilvers): figure out how to get the worker
-                  // to source the .bashrc like it did before.  Now I
-                  // think it's inheriting the PATH from the parent instead.
-                  // To export BOTO_CONFIG, for some reason, worker did not
-                  // source the .profile or .bashrc anymore.
-                  withEnv(["BOTO_CONFIG=/home/ubuntu/.boto",
-                           "PATH=/usr/local/google_appengine:" +
-                           "/home/ubuntu/google-cloud-sdk/bin:" +
-                           "/usr/local/bin/:" +
-                           "${env.HOME}/git-bigfile/bin:" +
-                           "${env.PATH}"]) {
+            withTimeout(timeoutString) {
+               // We document what machine we're running on, to help
+               // with debugging.
+               def instanceId = sh(
+                  script: ("curl -s " +
+                           "http://metadata.google.internal/computeMetadata/v1/instance/hostname " +
+                           "-H 'Metadata-Flavor: Google' | cut -d. -f1"),
+                  returnStdout: true).trim();
+               def ip = exec.outputOf(
+                  ["curl", "-s",
+                   "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip",
+                   "-H", 'Metadata-Flavor: Google']);
+               echo("Running on GCE instance ${instanceId} at ip ${ip}");
+               // TODO(csilvers): figure out how to get the worker
+               // to source the .bashrc like it did before.  Now I
+               // think it's inheriting the PATH from the parent instead.
+               // To export BOTO_CONFIG, for some reason, worker did not
+               // source the .profile or .bashrc anymore.
+               withEnv(["BOTO_CONFIG=/home/ubuntu/.boto",
+                        "PATH=/usr/local/google_appengine:" +
+                        "/home/ubuntu/google-cloud-sdk/bin:" +
+                        "/usr/local/bin/:" +
+                        "${env.HOME}/git-bigfile/bin:" +
+                        "${env.PATH}"]) {
+                  withVirtualenv() {
                      body();
                   }
                }

--- a/vars/withVirtualenv.groovy
+++ b/vars/withVirtualenv.groovy
@@ -14,10 +14,13 @@ def call(Closure body) {
       // because a node can inherit the environment from its parent
       // and have an inaccuarte VIRTUAL_ENV.
       echo("(Not activating virtualenv; already active at ${env.VIRTUAL_ENV})");
-      // TODO(csilvers): this is probably safe to remove now that we've
-      // changed the worker-ami creation script to do the downgrading too.
-      _maybeDowngradePip();
-      body();
+      // Make sure the virtual-env is still first in the path.
+      withEnv(["PATH=${env.VIRTUAL_ENV}/bin:${env.PATH}"]) {
+         // TODO(csilvers): this is probably safe to remove now that we've
+         // changed the worker-ami creation script to do the downgrading too.
+         _maybeDowngradePip();
+         body();
+      }
       return;
    }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
My latest change to install pip3 in /usr/local/bin (for keeper) had
the unfortunate effect that it made all the jobs prefer the pip3 in
/usr/local/bin to the python2 pip that lives in the virtualenv.  This
is because we accidentally were putting /usr/local/bin very high up in
the path, above the virtualenv.

I fix this in two ways:
1) I start the virtualenv *after* other path-munging, not before.
2) When we inherit the virtualenv (so we don't need to start it)
   I add the virtualenv dir to the front of PATH again, just in case.

The latter is necessary because in the "already-set-up" case
withVirtualenv leaves PATH alone, but onWorker munges PATH a second
time (so all its stuff is on PATH twice, oh well), which makes it so
the virtualenv isn't first again.  We fight that by prepending the
virtualenv path a second time too.

Issue: https://jenkins.khanacademy.org/job/deploy/job/webapp-test/131666

## Test plan:
https://jenkins.khanacademy.org/job/deploy/job/webapp-test/131669,
which has these changes locally (via `replay`), succeeded.