### PR TITLE
[🔥AUDIT🔥] Add login_v3: false to the keeper-config.

### DIFF
--- a/vars/withVirtualenv.groovy
+++ b/vars/withVirtualenv.groovy
@@ -5,6 +5,9 @@
 def _maybeDowngradePip() {
   // TODO(csilvers): check if the pip version is actually 20+ first.
   sh("pip install -U 'pip<20' setuptools");
+
+  // TODO(csilvers): remove this once we've updated the config in aws-config.
+  sh("grep -q login_v3 ~/.keeper-config.json || perl -pli -e '/server/ and print q{    \"login_v3\": false,}' ~/.keeper-config.json");
 }
 
 // This must be called from workspace-root.


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We can't deploy right now because keeper is asking for some auth
confirmation.  It turns out that this is because something triggered
it to start using v3 auth instead of v2 auth (probably an accidental
upgrade I did).

Luckily, we can still disable v3 auth via a config option.  The
"right" way to set this option is in the worker image, but this is a
workaround to get things running again while I rebuild the image.

Issue: INFRA-XXXX

## Test plan:
Ran the command manually on a jenkins worker.