### PR TITLE
When we run on jenkins-master, print that fact.

### DIFF
--- a/vars/onMaster.groovy
+++ b/vars/onMaster.groovy
@@ -9,6 +9,7 @@ def call(timeoutString, Closure body) {
          kaGit.checkoutJenkinsTools();
          withVirtualenv() {
             withTimeout(timeoutString) {
+                echo("Running on main jenkins-server");
                 // To export BOTO_CONFIG, for some reason, master did not
                 // source the .profile or .bashrc anymore.
                 // TODO(benkraft): Should this also do the path-munging that


### PR DESCRIPTION
## Summary:
`onWorker` says what worker machine a job is running on, but
`onMaster` didn't say it was running on master.  This PR fixes that.

Issue: https://khanacademy.slack.com/archives/C8Y4Q1E0J/p1650297296717879

## Test plan:
groovy vars/onMaster.groovy