### PR TITLE
Notify Jenkins build failures

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -7,6 +7,8 @@
 // This job runs lambdatest-cypress-cli in the webapp environment 
 // depending on how parameters are specified.
 
+// The Jenkins "interrupt" exception: for failFast and user interrupt
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 
 @Library("kautils")
 // Classes we use, under jenkins-jobs/src/.
@@ -16,7 +18,6 @@ import org.khanacademy.Setup;
 //import vars.notify
 //import vars.withTimeout
 //import vars.withSecrets
-
 
 new Setup(steps
 
@@ -76,49 +77,107 @@ Defaults to GIT_REVISION.""",
 def _setupWebapp() {
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", params.CYPRESS_GIT_REVISION);
 
+   // We need login creds for LambdaTest Cli
+   LT_USERNAME = sh(script: """\
+      keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
+      get qvYpo_KnpCiLBN69fYpEYA --format json | jq -r .login\
+      """, returnStdout:true).trim();
+   LT_ACCESS_KEY = sh(script: """\
+      keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
+      get qvYpo_KnpCiLBN69fYpEYA --format json | jq -r .password\
+      """, returnStdout:true).trim();
+
    dir("webapp/services/static") {
-      sh("yarn install")
+      sh("yarn install");
    }
 }
 
 def runLamdaTest() {
-   // We need login creds for LambdaTest Cli
-   def lt_username = sh(script: """\
-      keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
-      get qvYpo_KnpCiLBN69fYpEYA --format json | jq -r .login\
-      """, returnStdout:true).trim();
-   def lt_access_key = sh(script: """\
-      keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
-      get qvYpo_KnpCiLBN69fYpEYA --format json | jq -r .password\
-      """, returnStdout:true).trim();
-   
-   // TODO(ruslan): implement TEST_TYPE param to use decorator or flag 
+   // We use the build name as a unique identifier for user notifications. 
+   BUILD_NAME = "e2e-test #${env.BUILD_NUMBER} (${params.URL}: ${params.CYPRESS_GIT_REVISION}) @${params.DEPLOYER_USERNAME}"
+
+   // TODO(ruslan): Implement TEST_TYPE param to use decorator or flag 
    // in cypress script files. 
+   // TODO(ruslan): Use build tags --bt with prod/znd states.
    def runLambdaTestArgs = ["yarn",
                             "lambdatest",
                             "--cy=\"--config baseUrl=${params.URL}\", retries=${params.TEST_RETRIES}",
                             "--bn",
-                            "e2e-test # (${params.URL}: ${params.REVISION_DESCRIPTION}) @${params.DEPLOYER_USERNAME}",
+                            BUILD_NAME,
                             "-p",
-                            "${params.NUM_WORKER_MACHINES}"
+                            "${params.NUM_WORKER_MACHINES}",
+                            "--sync=true", 
+                            "--bt",
+                            "e2e-test #${env.BUILD_NUMBER}"
    ];
    
    dir('webapp/services/static') {
-      withEnv(["LT_USERNAME=${lt_username}",
-               "LT_ACCESS_KEY=${lt_access_key}"]) {
-         exec(runLambdaTestArgs)   
+         withEnv(["LT_USERNAME=${LT_USERNAME}",
+                  "LT_ACCESS_KEY=${LT_ACCESS_KEY}"]) {
+            exec(runLambdaTestArgs); 
       }
    }
 }
 
+// Notify users if build failed.
+def notifyFailures() {
+   def lambdaURL="https://api.lambdatest.com/automation/api/v1/builds"
+      
+   // Calling to LambdaTest for build name and id values,
+   // it will return 10 last build records.
+   // Retry 2 times if connection refused?
+   def response = sh(
+      script: "curl -s --retry-connrefused --retry 2 --retry-delay 5 " +
+              "${lambdaURL} -u ${LT_USERNAME}:${LT_ACCESS_KEY}", 
+      returnStdout: true).trim();
+   def status = sh(
+      script: "echo '$response' | jq -r '.data | map(select(.name ==" +
+              " \"${BUILD_NAME}\"))[0].status_ind'", 
+      returnStdout: true).trim();
+   def build_id = sh(
+      script: "echo '$response' | jq -r '.data | map(select(.name ==" +
+              " \"${BUILD_NAME}\"))[0].build_id'", 
+      returnStdout: true).trim();
+
+   // Send failure to the Slack.
+   // TODO(ruslan): Remove @ in extraText before merging with current e2e-test pipeline, 
+   // we don't want to disturb real users.  
+   def notifyMsg = [channel: params.SLACK_CHANNEL,
+                    sender: 'Testing Turtle',
+                    emoji: ':turtle:',
+                    extraText : 'Hey '+'@' + 
+                    params.DEPLOYER_USERNAME + 
+                    ' e2e-test #' + env.BUILD_NUMBER + 
+                    ' (' + params.URL + ': ' + 
+                    params.CYPRESS_GIT_REVISION + 
+                    ') FAILED (<https://automation.lambdatest.com/logs/?build='+build_id+'|Open>) \n ' +
+                    'The following build failed ' + 
+                    'https://automation.lambdatest.com/logs/?build='+build_id
+   ];
+
+   // TODO(ruslan): Do we need to assert if (code == 200) before and if not 
+   // raise an error?
+   if (status == null) {
+      // something went wrong 
+      notify.sendToSlack(notifyMsg + '@cypress-support something went wrong!', 'FAILURE');
+   } else if (status != "passed") {
+      // with custom status we won't send logs to #dev-support-log 
+      notify.sendToSlack(notifyMsg, 'LAMBDA_ERROR');
+   }
+}
+
+
 onWorker("ka-test-ec2", '6h') {
-   notify([slack: [channel: params.SLACK_CHANNEL,
-                  when: ['FAILURE', 'UNSTABLE']]]) {
+   notify([slack: [channel: '#cypress-testing',
+                   when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Sync webapp") {
          _setupWebapp();
       }
       stage("Run e2e tests") {
          runLamdaTest();
+      }
+      stage("Notify failures") {
+         notifyFailures();
       }
    }
 }

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -77,6 +77,8 @@ def _statusText(status, includeNumConsecutiveFailures=true) {
       return "is starting";
    } else if (status == "BACK TO NORMAL") {
       return "is back to normal";
+   } else if (status == "LAMBDA_ERROR") {
+      return "LambdaTest build failed";   
    } else {
       return "has unknown status (oops!)";
    }
@@ -164,6 +166,8 @@ def sendToSlack(slackOptions, status, extraText='') {
    if (status == "UNSTABLE") {
       emoji = slackOptions.emojiOnFailure ?: emoji;
       severity = 'warning';
+   } else if (status == "LAMBDA_ERROR") {
+      severity = 'error';   
    } else if (_failed(status)) {
       emoji = slackOptions.emojiOnFailure ?: emoji;
    }


### PR DESCRIPTION
## Summary:
With this pr we’re trying to use lambda api’s to get build&number status after lambda server work is done (by using sync flag) then notify deployer if the build is failed. At the same time, we don’t want to send test logs to dev-support-log channel during integration.

Issue: FEI-4478

## Test plan:
Run the script with replay on both main and notify scripts