### PR TITLE
[🔥AUDIT🔥] Suppres the test_push_sub log output when building current.sqlite.

### DIFF
--- a/build_current_sqlite.sh
+++ b/build_current_sqlite.sh
@@ -57,6 +57,13 @@ rm -rf webapp/genfiles/content_prefill
 cd webapp
 make deps
 
+# The analytics service spams many gigabytes of logs when receiving
+# `analytics-events` pubsubs events.  These logs are for CEDAR
+# development only and don't help us, so we just filter them out.
+# (everything from the "devOnly_push_sub_analytics" line to the next
+# blank line.
+perl -nli -e '$q = 1 if /devOnly_push_sub_analytics/; $q = 0 if /^\s*$/; print unless $q' pubsub.yaml
+
 # start dev server serving locally
 # go services assume graphql works on 8080 in dev
 # write logs to genfiles/appserver.log


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The `test_push_sub` endpoint is so noisy that the logs were filling up
the disk, causing the current.sqlite build to fail.  I hackily work
around it for now by just turning off the pubsub entry that calls that
endpoint.  We should really have a more principled solution, but this
is the most straightforward.

Issue: https://khanacademy.slack.com/archives/C02NV1DPJ/p1654708264283569

## Test plan:
I ran the new perl command manually and got this diff:
```
diff --git a/pubsub.yaml b/pubsub.yaml
index eae0c76864b..d99305efd1e 100644
--- a/pubsub.yaml
+++ b/pubsub.yaml
@@ -65,9 +65,6 @@

 - topic: analytics-events
   subscriptions:
-    devOnly_push_sub_analytics:
-      endpoint: https://analytics-dot-khan-academy.appspot.com/api/internal/pubsub/subscription/test_push_sub
-      ackDeadlineSeconds: 60

 - topic: article_revisions
   subscriptions:
```
which is what I intended.  Fingers crossed though that it works!  At
the least, I ran `make -C services/analytics serve` with the modified
pubsub.yaml and it didn't crash.