### PR TITLE
Add fake-gcs to the list of services started to build current.sqlite.

### DIFF
--- a/build_current_sqlite.sh
+++ b/build_current_sqlite.sh
@@ -28,9 +28,10 @@ function poll_for_service() {
 }
 
 function wait_for_service() {
-    # TODO(csilvers): poll something instead of just waiting for the first two.
+    # TODO(csilvers): poll something instead of just waiting for the first 3.
     case "$1" in
         grpc-translator) sleep 3;;
+        fake-gcs) sleep 7;;
         localproxy) sleep 5;;
         queryplanner) poll_for_service "$1" 8128;;
         graphql-gateway) poll_for_service "$1" 8102;;
@@ -88,7 +89,7 @@ redis_pid=$!
 # list This list is ordered! some of these services are early in the
 # list because other services depend on them to start.
 # For example: grpc-translator and graphql-gateway
-required_services="grpc-translator localproxy queryplanner graphql-gateway admin analytics assignments campaigns coaches content content-editing content-library discussions districts donations emails progress rest-gateway rewards search test-prep users"
+required_services="grpc-translator fake-gcs localproxy queryplanner graphql-gateway admin analytics assignments campaigns coaches content content-editing content-library discussions districts donations emails progress rest-gateway rewards search test-prep users"
 
 # We also need to start the go services
 service_pids=


### PR DESCRIPTION
## Summary:
We can't run `make serve` in build_current_sqlite.sh because, um, it
didn't work for some reason.  I think INFRA-7279 has more details.  In
any case, this means we need to list the services to start manually.

It's easy to forget to do this, and indeed we did forget when we added
fake-gcs as a service-dependency in #5869.  This change adds it there.

Note that we will have to get mkcert working no the jenkins machines
as well.  That will be a separate diff (in a separate repo).

Issue:  https://khanacademy.slack.com/archives/C01120CNCS0/p1654719166232869

## Test plan:
Fingers crossed.