### PR TITLE
Add sendToGithub to Jenkins and wire up into webapp-test job.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -530,6 +530,7 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
                    when: ['FAILURE', 'UNSTABLE']],
+           github: [sha: params.GIT_REVISION],
            buildmaster: [sha: params.GIT_REVISION,
                          what: 'webapp-test']]) {
       initializeGlobals();
@@ -539,7 +540,7 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
             runTests();
          }
       } finally {
-         // If we determined there were no tests to run, we should skip 
+         // If we determined there were no tests to run, we should skip
          // analysis since it fails if there are no test results.
          if (skipTestAnalysis) {
             echo("Skipping Analysis - No tests run")

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -530,7 +530,8 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
                    when: ['FAILURE', 'UNSTABLE']],
-           github: [sha: params.GIT_REVISION],
+           github: [sha: params.GIT_REVISION,
+                    context: 'webapp-test'],
            buildmaster: [sha: params.GIT_REVISION,
                          what: 'webapp-test']]) {
       initializeGlobals();

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -187,6 +187,7 @@ def sendToSlack(slackOptions, status, extraText='') {
 // Update the Github commit status
 // Supported options:
 //  - sha: The commit SHA to update the status of.
+//  - context: The name of the what the results represent (defaults to Jenkins).
 //  - repo: The repo to update the status in (defaults to webapp).
 //  - owner: The owner of the repo (defaults to Khan).
 def sendToGithub(githubOptions, status, extraText='') {
@@ -205,11 +206,13 @@ def sendToGithub(githubOptions, status, extraText='') {
       githubStatus = "success";
    }
 
-   def flags = ["--github-sha='${githubOptions.sha}'",
-                "--github-target-url='${env.BUILD_URL}'",
-                "--github-status='${githubStatus}'",
-                "--github-summary='${subject}'"
-                "--github-context='Jenkins'"];
+   def context = githubOptions.context ?: "Jenkins";
+
+   def flags = ["--github-sha=${githubOptions.sha}",
+                "--github-target-url=${env.BUILD_URL}",
+                "--github-status=${githubStatus}",
+                "--summary=${subject}",
+                "--github-context=${context}"];
 
    if (githubOptions.repo) {
       flags += ["--github-repo=${githubOptions.repo}"];

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -184,6 +184,44 @@ def sendToSlack(slackOptions, status, extraText='') {
    }
 }
 
+// Update the Github commit status
+// Supported options:
+//  - sha: The commit SHA to update the status of.
+//  - repo: The repo to update the status in (defaults to webapp).
+//  - owner: The owner of the repo (defaults to Khan).
+def sendToGithub(githubOptions, status, extraText='') {
+   def arr = _dataForAlertlib(status, extraText);
+   def subject = arr[0];
+   def severity = arr[1];
+   def body = arr[2];
+   subject += "${currentBuild.displayName}";
+
+   // Everything that isn't a failure or a success is reported as "pending"
+   def githubStatus = "pending";
+
+   if (_failed(status)) {
+      githubStatus = "failure";
+   } else if (_shouldReport(status, ["SUCCESS"])) {
+      githubStatus = "success";
+   }
+
+   def flags = ["--github-sha='${githubOptions.sha}'",
+                "--github-target-url='${env.BUILD_URL}'",
+                "--github-status='${githubStatus}'",
+                "--github-summary='${subject}'"
+                "--github-context='Jenkins'"];
+
+   if (githubOptions.repo) {
+      flags += ["--github-repo=${githubOptions.repo}"];
+   }
+
+   if (githubOptions.owner) {
+      flags += ["--github-owner=${githubOptions.owner}"];
+   }
+
+   _sendToAlertlib(subject, severity, body, flags);
+}
+
 
 // Supported options:
 // when (required): under what circumstances to send to email; a list.
@@ -304,6 +342,9 @@ def call(options, Closure body) {
       if (options.buildmaster) {
          sendToBuildmaster(options.buildmaster, "BUILD START");
       }
+      if (options.github) {
+         sendToGithub(options.github, "BUILD START");
+      }
 
       // We do this `parallel` to catch when the job has been aborted.
       // http://stackoverflow.com/questions/36855066/how-to-query-jenkins-to-determine-if-a-still-building-pipeline-job-has-been-abor
@@ -373,6 +414,9 @@ def call(options, Closure body) {
          if (!env.SENT_TO_SLACK) {
             sendToSlack(options.slack, status, failureText);
          }
+      }
+      if (options.github) {
+         sendToGithub(options.github, status, failureText);
       }
       if (options.email && _shouldReport(status, options.email.when)) {
          sendToEmail(options.email, status, failureText);


### PR DESCRIPTION
## Summary:
This wires up the new Github status check logic added to alertlib into the notify.groovy logic - making it so that the status check is added to the current commit SHA that we're working against. I made sure to add in calls to `sendToGithub` in the `call` method on both build start and completion, this will allow us to see the "pending" state more accurately in Github.

Issue: FEI-4621

## Test plan:
I was able to test this by taking an existing test run:
https://jenkins.khanacademy.org/job/deploy/job/webapp-test/142238/

and then I clicked "Replay" and modified the Main Script and Notify to match what's in this PR and I was able to get working results!
https://jenkins.khanacademy.org/job/deploy/job/webapp-test/142250/

Pending:
![Screen Shot 2022-06-23 at 1 18 30 PM](https://user-images.githubusercontent.com/1615/175362132-a2319555-e192-43be-9992-79eed48c0073.jpg)

Back to normal:
![Screen Shot 2022-06-23 at 1 16 17 PM](https://user-images.githubusercontent.com/1615/175362072-c19374e2-73b6-434f-8a8b-d25ee1cd3399.jpg)

Success:
![Screen Shot 2022-06-23 at 1 19 00 PM](https://user-images.githubusercontent.com/1615/175362586-8a2f2f3d-c892-47ab-b07b-4c22a30ffc01.jpg)

