### PR TITLE
Run LT/Cypress e2e tests sequentially.

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -598,10 +598,7 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
 
       try {
          stage("Running smoketests") {
-            parallel([
-               "run-tests": { runTests(); },
-               "test-lambdacli": { runLambda(); },
-            ]);
+            runTests();
          }
       } finally {
          // If we determined there were no tests to run, we should skip 
@@ -616,6 +613,15 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
          stage("Analyzing results") {
             analyzeResults();
          }
+
+         // We want to run the Cypress e2e tests only after the official e2e
+         // tests are completed. By doing this we can prevent introducing any
+         // possible issues to the deploys.  
+         // NOTE: This will be changed once we stabilize our Cypress/LambdaTest
+         // infra.
+         state("Runnning Cypress e2e tests") {
+            runLambda();
+         } 
       }
    }
 }

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -619,7 +619,7 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
          // possible issues to the deploys.  
          // NOTE: This will be changed once we stabilize our Cypress/LambdaTest
          // infra.
-         state("Runnning Cypress e2e tests") {
+         stage("Runnning Cypress e2e tests") {
             runLambda();
          } 
       }


### PR DESCRIPTION
## Summary:

There's an issue with the existing logic where we try to parallelize
Python/Selenium and Cypress/LambdaTest e2e tests. For some unknown
reason, LT is not being able to start some tests causing the entire test
suite to fail, and by using `parallel`, we're also seeing the main e2e
job having to wait until LT resolves (it's currently resolving after 1
hour of timeout).

This PR fixes that issue by running the LT/Cypress tests sequentially
only after the main e2e tests are completed.

Issue: XXX-XXXX

## Test plan:

Verify that the e2e job iss reporting times as before.