### PR TITLE
Allow multiple LambdaTest runs to execute concurrently

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -18,7 +18,10 @@ import org.khanacademy.Setup;
 
 new Setup(steps
 
-).addStringParam(
+.allowConcurrentBuilds(
+
+// Allow multiple LambdaTest runs to execute concurrently.
+)).addStringParam(
    "CYPRESS_GIT_REVISION",
    """The name of a cypress branch to use when building.""",
    "feature/cypress"


### PR DESCRIPTION
## Summary:
There's no good reason to only allow a single e2e-test-cypress job at a time, all the heavy lifting is done by the LambdaTest system, which is already heavily parallelized. While it doesn't really HURT us to not run the tests concurrently now that the e2e-test job doesn't wait on the result of this job, it's still creates a massive queue of jobs for no clear reason. Because of the way jenkins won't tell you deatils about queued jobs until it's running, it's especially hard to figure out when a given e2e-test-cypress job will run or what the status of it is.

Issue: None

## Test plan:
Cross fingers. Twice.