### PR TITLE
FEI-4674: Merge in 'master' when deploying ZNDs

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -337,6 +337,12 @@ def deploy() {
       kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
                              params.GIT_REVISION);
 
+      // We merge `master` into the current revision before deploying the ZND
+      // so that the ZND is deployed using out of date processes.  We call this
+      // function directly instead of relying on the merge-branches job because
+      // deploy-znd isn't facilitated by buildmaster.
+      kaGit.mergeBranches("master+" + params.GIT_REVISION, VERSION);
+
       dir("webapp") {
          clean(params.CLEAN);
          sh("make python_deps");

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -338,7 +338,7 @@ def deploy() {
                              params.GIT_REVISION);
 
       // We merge `master` into the current revision before deploying the ZND
-      // so that the ZND is deployed using out of date processes.  We call this
+      // so that the ZND isn't deployed using out of date processes.  We call this
       // function directly instead of relying on the merge-branches job because
       // deploy-znd isn't facilitated by buildmaster.
       kaGit.mergeBranches("master+" + params.GIT_REVISION, VERSION);

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -155,7 +155,9 @@ onMaster('1h') {
                    when: ['FAILURE', 'UNSTABLE']]]) {
       try {
          checkArgs();
-         def sha1 = mergeBranches();
+         tag_name = ("buildmaster-${params.COMMIT_ID}-" +
+                     "${new Date().format('yyyyMMdd-HHmmss')}");
+         def sha1 = kaGit.mergeBranches(params.GIT_REVISIONS, tag_name);
          def gae_version_name = getGaeVersionName();
          buildmaster.notifyMergeResult(params.COMMIT_ID, 'success',
                                        sha1, gae_version_name);

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -79,65 +79,6 @@ def checkArgs() {
 }
 
 
-def mergeBranches() {
-   // We don't use kaGit for many of the ops here, and use lower-level ops
-   // where we do. We can afford this because we don't need to update
-   // submodules at each step, and we don't need a fully clean checkout.  All
-   // we need is enough to merge.  This saves us a *lot* of time traversing all
-   // the submodules on each branch, and being careful to clean at each step.
-   def allBranches = params.GIT_REVISIONS.split(/\+/);
-   kaGit.quickClone("git@github.com:Khan/webapp", "webapp",
-                    allBranches[0].trim());
-   dir('webapp') {
-      // We need to reset before fetching, because if a previous incomplete
-      // merge left .gitmodules in a weird state, git will fail to read its
-      // config, and even the fetch can fail.  This also avoids certain
-      // post-merge-conflict states where git checkout -f doesn't reset as much
-      // as you might think.
-      exec(["git", "reset", "--hard"]);
-   }
-   kaGit.quickFetch("webapp");
-   dir('webapp') {
-      for (def i = 0; i < allBranches.size(); i++) {
-         def branchSha1 = kaGit.resolveCommitish("git@github.com:Khan/webapp",
-                                                 allBranches[i].trim());
-         try {
-            if (i == 0) {
-               // TODO(benkraft): If there's only one branch, skip the checkout
-               // and tag/return sha1 immediately.
-               // Note that this is a no-op when we did a fresh clone above.
-               exec(["git", "checkout", "-f", branchSha1]);
-            } else {
-               // TODO(benkraft): This puts the sha in the commit message
-               // instead of the branch; we should just write our own commit
-               // message.
-               exec(["git", "merge", branchSha1]);
-            }
-         } catch (e) {
-            // TODO(benkraft): Also send the output of the merge command that
-            // failed.
-            notify.fail("Failed to merge ${branchSha1} into " +
-                        "${allBranches[0..<i].join(' + ')}: ${e}");
-         }
-      }
-      // We need to at least tag the commit, otherwise github may prune it.
-      // (We can skip this step if something already points to the commit; in
-      // fact we want to to avoid Phabricator paying attention to this commit.)
-      // TODO(benkraft): Prune these tags eventually.
-      if (exec.outputOf(["git", "tag", "--points-at", "HEAD"]) == "" &&
-          exec.outputOf(["git", "branch", "-r", "--points-at", "HEAD"]) == "") {
-         tag_name = ("buildmaster-${params.COMMIT_ID}-" +
-                     "${new Date().format('yyyyMMdd-HHmmss')}");
-         exec(["git", "tag", tag_name, "HEAD"]);
-         exec(["git", "push", "--tags", "origin"]);
-      }
-      def sha1 = exec.outputOf(["git", "rev-parse", "HEAD"]);
-      echo("Resolved ${params.GIT_REVISIONS} --> ${sha1}");
-      return sha1;
-   }
-}
-
-
 def getGaeVersionName() {
    dir('webapp') {
      def gae_version_name = exec.outputOf(["make", "gae_version_name"]);

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -182,18 +182,14 @@ def safeMergeFromMaster(dir, commitToMergeInto, submodules=[]) {
 // 
 // Arguments:
 // - gitRevisions: string containing one or more branche names separated by "+"
-// - tagName: string to tag the resulting commit with
+// - tagName: string to tag the resulting commit with.  We need to tag the 
+//   result of the merge so git doesn't prune it.
 //
 // Notes:
 // - Used by merge-granches.groovy and deploy-znd.groovy.
 def mergeBranches(gitRevisions, tagName) {
-   // We don't use kaGit for many of the ops here, and use lower-level ops
-   // where we do. We can afford this because we don't need to update
-   // submodules at each step, and we don't need a fully clean checkout.  All
-   // we need is enough to merge.  This saves us a *lot* of time traversing all
-   // the submodules on each branch, and being careful to clean at each step.
    def allBranches = gitRevisions.split(/\+/);
-   kaGit.quickClone("git@github.com:Khan/webapp", "webapp",
+   quickClone("git@github.com:Khan/webapp", "webapp",
                     allBranches[0].trim());
    dir('webapp') {
       // We need to reset before fetching, because if a previous incomplete
@@ -203,11 +199,11 @@ def mergeBranches(gitRevisions, tagName) {
       // as you might think.
       exec(["git", "reset", "--hard"]);
    }
-   kaGit.quickFetch("webapp");
+   quickFetch("webapp");
    dir('webapp') {
       for (def i = 0; i < allBranches.size(); i++) {
-         def branchSha1 = kaGit.resolveCommitish("git@github.com:Khan/webapp",
-                                                 allBranches[i].trim());
+         def branchSha1 = resolveCommitish("git@github.com:Khan/webapp",
+                                           allBranches[i].trim());
          try {
             if (i == 0) {
                // TODO(benkraft): If there's only one branch, skip the checkout

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -176,3 +176,68 @@ def safeMergeFromMaster(dir, commitToMergeInto, submodules=[]) {
             dir, commitToMergeInto] + _submodulesArg(submodules));
    }
 }
+
+
+// Merges multiple branches together into a single commit.
+// 
+// Arguments:
+// - gitRevisions: string containing one or more branche names separated by "+"
+// - tagName: string to tag the resulting commit with
+//
+// Notes:
+// - Used by merge-granches.groovy and deploy-znd.groovy.
+def mergeBranches(gitRevisions, tagName) {
+   // We don't use kaGit for many of the ops here, and use lower-level ops
+   // where we do. We can afford this because we don't need to update
+   // submodules at each step, and we don't need a fully clean checkout.  All
+   // we need is enough to merge.  This saves us a *lot* of time traversing all
+   // the submodules on each branch, and being careful to clean at each step.
+   def allBranches = gitRevisions.split(/\+/);
+   kaGit.quickClone("git@github.com:Khan/webapp", "webapp",
+                    allBranches[0].trim());
+   dir('webapp') {
+      // We need to reset before fetching, because if a previous incomplete
+      // merge left .gitmodules in a weird state, git will fail to read its
+      // config, and even the fetch can fail.  This also avoids certain
+      // post-merge-conflict states where git checkout -f doesn't reset as much
+      // as you might think.
+      exec(["git", "reset", "--hard"]);
+   }
+   kaGit.quickFetch("webapp");
+   dir('webapp') {
+      for (def i = 0; i < allBranches.size(); i++) {
+         def branchSha1 = kaGit.resolveCommitish("git@github.com:Khan/webapp",
+                                                 allBranches[i].trim());
+         try {
+            if (i == 0) {
+               // TODO(benkraft): If there's only one branch, skip the checkout
+               // and tag/return sha1 immediately.
+               // Note that this is a no-op when we did a fresh clone above.
+               exec(["git", "checkout", "-f", branchSha1]);
+            } else {
+               // TODO(benkraft): This puts the sha in the commit message
+               // instead of the branch; we should just write our own commit
+               // message.
+               exec(["git", "merge", branchSha1]);
+            }
+         } catch (e) {
+            // TODO(benkraft): Also send the output of the merge command that
+            // failed.
+            notify.fail("Failed to merge ${branchSha1} into " +
+                        "${allBranches[0..<i].join(' + ')}: ${e}");
+         }
+      }
+      // We need to at least tag the commit, otherwise github may prune it.
+      // (We can skip this step if something already points to the commit; in
+      // fact we want to to avoid Phabricator paying attention to this commit.)
+      // TODO(benkraft): Prune these tags eventually.
+      if (exec.outputOf(["git", "tag", "--points-at", "HEAD"]) == "" &&
+          exec.outputOf(["git", "branch", "-r", "--points-at", "HEAD"]) == "") {
+         exec(["git", "tag", tagName, "HEAD"]);
+         exec(["git", "push", "--tags", "origin"]);
+      }
+      def sha1 = exec.outputOf(["git", "rev-parse", "HEAD"]);
+      echo("Resolved ${gitRevisions} --> ${sha1}");
+      return sha1;
+   }
+}


### PR DESCRIPTION
## Summary:
The regular deploy process merges 'master' into the deploy branch before deploying.  We want to do the same when deploying ZNDs.  This will avoid issues that can occur if a ZND is being deployed with out-of-date deploy scripts.

Issue: FEI-4674

Questions:
- Do we want to change GIT_REVISION to GIT_REVISIONS and allow people to deploy a ZND using multiple branches?

## Test plan:
- visit a page like https://jenkins.khanacademy.org/job/deploy/job/deploy-znd/5254/
- click on replay on the left pane. Replace the contents of the "main script" window with your new deploy-znd.groovy code
- Replce the contents of the "kaGit" window with your new kaGit.groovy code
- click "run" and see how the job does

```
...
17:02:51  'kevinb-fixes' resolves to bd2f7ca76da4b854c98f24bb340072c73be64a61
[Pipeline] sh
17:02:51  + git merge bd2f7ca76da4b854c98f24bb340072c73be64a61
17:02:51  Already up to date.
[Pipeline] sh

17:02:51  + git tag --points-at HEAD
[Pipeline] sh

17:02:52  + git rev-parse HEAD
[Pipeline] echo
17:02:52  Resolved master+kevinb-fixes --> 68711adc564fdb1a23685c4c93dacfd02ded95ef
...
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```

- [x] repeat with a deploy-znd job that's been run for a branch that will have a merge conflict with `master`

https://jenkins.khanacademy.org/job/deploy/job/deploy-znd/5283 shows a deploy-znd failure due to merge conflict.  The error is reported in slack as a generic failure, but it's easy enough to track down the issue in the logs.  I'm going to leave it like this for now, but may circle back later to add a custom Slack message.  Here's what the logs looked like for the failure:
```
10:08:11  Failure message: Failed to merge 4b466c3815e7033565b72b1916ef3bcef8f472f2 into master: hudson.AbortException: script returned exit code 1
[Pipeline] ansiColor
[Pipeline] {
10:08:11  
[Pipeline] echo
10:08:11  ===== JOB FAILED =====
```