### PR TITLE
Enforce ZND to use lowercase version name.

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -168,7 +168,7 @@ def determineVersion() {
    // VERSION parameter needs to be lowercased.
    // Otherwise Fastly will have issue looking up the static version as it expects
    // lowercase hostname.
-   VERSION = "znd-${date}-${_currentUser()}-${params.VERSION.toLowerCase()}";
+   VERSION = "znd-${date}-${_currentUser()}-${params.VERSION}".toLowerCase();
 
    // DNS has a limit of 63 bytes per hostname-component.  This
    // version can yield hostname-components like

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -165,7 +165,10 @@ def determineVersion() {
    }
 
    def date = new Date().format("yyMMdd");
-   VERSION = "znd-${date}-${_currentUser()}-${params.VERSION}";
+   // VERSION parameter needs to be lowercased.
+   // Otherwise Fastly will have issue looking up the static version as it expects
+   // lowercase hostname.
+   VERSION = "znd-${date}-${_currentUser()}-${params.VERSION.toLowerCase()}";
 
    // DNS has a limit of 63 bytes per hostname-component.  This
    // version can yield hostname-components like


### PR DESCRIPTION
## Summary:
As discovered during our ZND testing, if a ZND contains uppercase,
we will fail to lookup the static version in Fastly (see slack thread in issue).

Also from
https://github.com/Khan/jenkins-jobs/commit/d2dc0da5d3418682e222e3b9e2238d058bbb5864
it looks like previously we expect lowercase also.  So let's make the
version name lowercase.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1658776260277369

## Test plan:
- Create a new ZND job using uppercase ZND name https://jenkins.khanacademy.org/job/deploy/job/deploy-znd/5292/
- Select replay from above job and copy and paste the modified deploy-znd.groovy, and Run the job https://jenkins.khanacademy.org/job/deploy/job/deploy-znd/5293/.
- Confirm the new version https://prod-znd-220725-boris-up.khanacademy.org/_api/version is indeed working.

![image](https://user-images.githubusercontent.com/1215939/180877252-efb6608b-87d6-4d25-99e3-db34c9ec8d4c.png)

(note the different in the case of the ZND)