### PR TITLE
[🔥AUDIT🔥] Cypress: Switch to master as default branch

### DIFF
--- a/jobs/e2e-test-cypress-backup.groovy
+++ b/jobs/e2e-test-cypress-backup.groovy
@@ -21,7 +21,7 @@ new Setup(steps
 ).addStringParam(
    "CYPRESS_GIT_REVISION",
    """The name of a cypress branch to use when building.""",
-   "feature/cypress"
+   "master"
 
 ).addStringParam(
    "URL",

--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -24,7 +24,7 @@ new Setup(steps
 ).addStringParam(
    "CYPRESS_GIT_REVISION",
    """The name of a cypress branch to use when building.""",
-   "feature/cypress"
+   "master"
 
 ).addStringParam(
    "URL",


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Now that engineers have started to work on creating and/or porting e2e tests in
Cypress, we can safely use `master` as the default branch for running tests with
LambdaTest.

Issue: XXX-XXXX

## Test plan:

Verify that the builds run more consistently and that the `321-happy-path.spec.js` tests go back to normal.