### PR TITLE
e2e-test-cypress Jenkins job is not running against current commit hash

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -22,7 +22,7 @@ new Setup(steps
 
 // Allow multiple LambdaTest runs to execute concurrently.
 ).addStringParam(
-   "CYPRESS_GIT_REVISION",
+   "GIT_REVISION",
    """The name of a cypress branch to use when building.""",
    "master"
 
@@ -80,8 +80,14 @@ BUILD_NAME = "build e2e-cypress-test #${env.BUILD_NUMBER} (${params.URL}: ${para
 // At this time removing @ before username.
 DEPLOYER_USER = params.DEPLOYER_USERNAME.replace("@", "")
 
+// GIT_SHA1 is the sha1 for GIT_REVISION.
+GIT_SHA1 = null;
+
 def _setupWebapp() {
-   kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", params.CYPRESS_GIT_REVISION);
+   GIT_SHA1 = kaGit.resolveCommitish("git@github.com:Khan/webapp",
+                                        params.GIT_REVISION);
+
+   kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", GIT_SHA1);
 
    dir("webapp/services/static") {
       sh("yarn install");
@@ -104,7 +110,7 @@ def runLamdaTest() {
    // TODO(ruslan): Use build tags --bt with prod/znd states.
    def runLambdaTestArgs = ["yarn",
                             "lambdatest",
-                            "--cy='--config baseUrl=\"${params.URL}\"'",
+                            "--cy='--config baseUrl=\"${params.URL}\",retries=${params.TEST_RETRIES}'",
                             "--bn='${BUILD_NAME}'",
                             "-p=${params.NUM_WORKER_MACHINES}",
                             "--sync=true", 

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -490,6 +490,7 @@ def runLambda(){
              string(name: 'URL', value: E2E_URL),
              string(name: 'NUM_WORKER_MACHINES', value: params.NUM_WORKER_MACHINES),
              string(name: 'TEST_RETRIES', value: "1"),
+             string(name: 'GIT_REVISION', value: params.GIT_REVISION),
             // It takes about 5 minutes to run all the Cypress e2e tests when
             // using the default of 20 workers. This build is running in parallel
             // with runTests(). During this test run we don't want to disturb our 


### PR DESCRIPTION
## Summary:
We are trying to deploy a fix for a flaky test but LT still thinks that is an error
This is happening because we are using master to run the tests, so we are testing the “old” version of that test,
instead of the commit that includes the changes.

Issue: FEI-4724

## Test plan:
run replay