### PR TITLE
[🔥AUDIT🔥] Clear out the ka-lint cache when running tests on jenkins.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -213,6 +213,9 @@ def _setupWebapp() {
    dir("webapp") {
       clean(params.CLEAN);
       sh("make python_deps");
+      // We always delete the ka-lint cache so we run all lints every time.
+      // In theory we could use the cache, but just to be safe...
+      sh("rm -rf genfiles/ka-lint");
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The ka-lint cache is really useful for avoiding unnecessary lints in
dev.  In theory we could save the same work at deploy-time (and other
times) on jenkins.  But we want to be extra sure everything is ok,
when we run on Jenkins, so I want to suppress the cache there.

The easiest way to do that is to just delete the cache at the
beginning of every test-run, which is what I do in this PR.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1661765927139029

## Test plan:
Fingers crossed