### PR TITLE
[🔥AUDIT🔥] Always refer to the current revision by sha, not name.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -243,10 +243,10 @@ def runTestServer() {
          // changed between BASE_REVISION and GIT_REVISION.  We ignore
          // files where only sync tags have changed; those can't affect
          // tests.
-         sh("deploy/trivial_diffs.py ${exec.shellEscape(params.BASE_REVISION)} ${exec.shellEscape(params.GIT_REVISION)} > ../trivial_diffs.txt");
-         sh("git diff --name-only --diff-filter=ACMRTUB ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(params.GIT_REVISION)} | fgrep -vx -f ../trivial_diffs.txt | testing/all_tests_for.py - > ../files_to_test.txt");
+         sh("deploy/trivial_diffs.py ${exec.shellEscape(params.BASE_REVISION)} ${exec.shellEscape(GIT_SHA1)} > ../trivial_diffs.txt");
+         sh("git diff --name-only --diff-filter=ACMRTUB ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} | fgrep -vx -f ../trivial_diffs.txt | testing/all_tests_for.py - > ../files_to_test.txt");
          // Note that unlike for tests, we consider deleted files for linting.
-         sh("git diff --name-only --diff-filter=ACMRTUBD ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(params.GIT_REVISION)} | testing/all_lint_for.py - > ../files_to_lint.txt");
+         sh("git diff --name-only --diff-filter=ACMRTUBD ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} | testing/all_lint_for.py - > ../files_to_lint.txt");
       } else {
          sh("echo > ../trivial_diffs.txt");
          sh("echo . > ../files_to_test.txt");


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
`GIT_REVISION` could be a symbolic name, like `master` or `csilvers`.
We convert it to a sha once at the beginning of webapp-test, and use
the sha everywhere in the script, to protect against changes in the
branch between the time the script starts and when it ends.  But we
missed one place that was still using GIT_REVISION.  Now it's fixed
too.

Issue: https://jenkins.khanacademy.org/job/deploy/job/webapp-test/150581/consoleText

## Test plan:
I ran a job successfully with these changes:
   https://jenkins.khanacademy.org/job/deploy/job/webapp-test/150583/console