### PR TITLE
[🔥AUDIT🔥] Set up path on master like we do on the workers.

### DIFF
--- a/vars/onMaster.groovy
+++ b/vars/onMaster.groovy
@@ -10,11 +10,16 @@ def call(timeoutString, Closure body) {
          withVirtualenv() {
             withTimeout(timeoutString) {
                 echo("Running on main jenkins-server");
-                // To export BOTO_CONFIG, for some reason, master did not
+                // TODO(csilvers): figure out how to get the worker
+                // to source the .bashrc like it did before.  Now I
+                // think it's inheriting the PATH from the parent instead.
+                // To export BOTO_CONFIG, for some reason, worker did not
                 // source the .profile or .bashrc anymore.
-                // TODO(benkraft): Should this also do the path-munging that
-                // onWorker does?
-                withEnv(["BOTO_CONFIG=${env.HOME}/.boto"]) {
+                withEnv(["BOTO_CONFIG=${env.HOME}/.boto",
+                         "PATH=/usr/local/google_appengine:" +
+                         "/home/ubuntu/google-cloud-sdk/bin:" +
+                         "${env.HOME}/git-bigfile/bin:" +
+                         "${env.PATH}"]) {
                      body();
                 }
             }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
For some resaon, with the Jenkins upgrade Jenkins no longer reads
`.profile` on the main (jenkins-server) machine, matching the behavior
it's had on the workers for a while.  We worked around that in
`onWorker`.  Now we apply the same workaround in `onMaster`.  This
matches a TODO (though doesn't resolve it, since our workaround is
still a hack).

Issue: https://jenkins.khanacademy.org/job/misc/job/update-ownership-data/1213/

## Test plan:
I went to
   https://jenkins.khanacademy.org/job/misc/job/update-ownership-data/1213/
and clicked on `replay` and replaced the contents of onMaster.groovy
with the new version in this PR, and ran it with success.