### PR TITLE
FEI-4766.2: Tag LambdaTest builds per environment / CI platform

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -104,6 +104,8 @@ def runLamdaTest() {
       keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
       get qvYpo_KnpCiLBN69fYpEYA --format json | jq -r .password\
       """, returnStdout:true).trim();
+
+   def e2eEnv = params.URL == "https://www.khanacademy.org" ? "prod" : "preprod";
    
    // TODO(ruslan): Implement TEST_TYPE param to use decorator or flag 
    // in cypress script files. 
@@ -114,7 +116,7 @@ def runLamdaTest() {
                             "--bn='${BUILD_NAME}'",
                             "-p=${params.NUM_WORKER_MACHINES}",
                             "--sync=true", 
-                            "--bt='e2e-test #${env.BUILD_NUMBER}'",
+                            "--bt='jenkins,${e2eEnv}'",
                             "--eof"
    ];
    


### PR DESCRIPTION
## Summary:
Second change to align on how we tag LambdaTest builds.

The idea is to include tags to builds so we can start filtering builds
by env and platform, so we can start collecting better metrics around
possible flaky tests depending on the tag.

These will be the tags we'll be using from now on:

By environment: `prod` | `preprod` | `znd`.
By CI platform: `github` | `jenkins`.

This PR is responsible for doing the Jenkins-related changes to support
these tags.

In the `jenkins-job` context, we will be supporting the following
combinations:

- `preprod,jenkins` (e.g. first smoke tests or http://prod-someid-somehash.khanacademy.org)
- `prod,jenkins` (e.g. second smoke tests or http://khanacademy.org)

Issue: FEI-4766

## Test plan

Used the Jenkins replay feature to test changes to this job.

- First replay runs against a `preprod` build.

https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/3141/console
https://automation.lambdatest.com/build?build=7684085

- Second replay runs against a `prod` build.

https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/3142/console
https://automation.lambdatest.com/build?build=7684301