### PR TITLE
Figure out what tests need to be run for deleted files, too.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -245,6 +245,8 @@ def runTestServer() {
          // tests.
          sh("deploy/trivial_diffs.py ${exec.shellEscape(params.BASE_REVISION)} ${exec.shellEscape(GIT_SHA1)} > ../trivial_diffs.txt");
          sh("git diff --name-only --diff-filter=ACMRTUB ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} | fgrep -vx -f ../trivial_diffs.txt | testing/all_tests_for.py - > ../files_to_test.txt");
+         // Sometimes we need to run some extra tests for deletd files.
+         sh("git diff --name-only --diff-filter=D ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} | fgrep -vx -f ../trivial_diffs.txt | testing/all_tests_for.py --deleted-mode - >> ../files_to_test.txt");
          // Note that unlike for tests, we consider deleted files for linting.
          sh("git diff --name-only --diff-filter=ACMRTUBD ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} | testing/all_lint_for.py - > ../files_to_lint.txt");
       } else {


### PR DESCRIPTION
## Summary:
We had an issue where there was a deploy that deleted one python file,
which made a second python file unused (since the deleted python file
was the only client).  But we didn't catch the problem because jenkins
doesn't call all_tests_for.py on deleted files.  On the face of it
that's reasonable: what tests could you possibly have on code that
doesn't exist?!  But there are some consistency tests that care, such
as unused_file_test.py.

This PR tells jenkins to look for that case, using a new
`--deleted-mode` flag on all_tests_for.py.

Depends on https://github.com/Khan/webapp/pull/8816.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1663856692389019

## Test plan:
Will run a webapp-test job using this new arg once https://github.com/Khan/webapp/pull/8816 is landed.