### PR TITLE
Increment Cypress retries in Jenkins

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -56,8 +56,8 @@ Defaults to GIT_REVISION.""",
 
 ).addStringParam(
    "TEST_RETRIES",
-   """How many retry attempts to use. By default is 1.""",
-   "1"
+   """How many retry attempts to use. By default is 3.""",
+   "3"
 
 ).addChoiceParam(
    "TEST_TYPE",


### PR DESCRIPTION
## Summary:

Incrementing the Cypress retries from 1 to 3 to help us decreasing build
failures from LambdaTest.

Issue: "none"

## Test plan:

Verify that LambdaTest builds are starting to get more positive results when
being triggered from deploys.