### PR TITLE
[🔥AUDIT🔥] Increment Cypress retries in main e2e-test job

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -489,7 +489,7 @@ def runLambda(){
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),
              string(name: 'NUM_WORKER_MACHINES', value: params.NUM_WORKER_MACHINES),
-             string(name: 'TEST_RETRIES', value: "1"),
+             string(name: 'TEST_RETRIES', value: "3"),
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
             // It takes about 5 minutes to run all the Cypress e2e tests when
             // using the default of 20 workers. This build is running in parallel


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Incrementing the number of Cypress retries in the `e2e-test` jenkins job to 3.

We previously set it directly in the e2e-test-cypress job, but I noticed that
this was being override in the main test job.

Issue: XXX-XXXX

## Test plan:

N/A