### PR TITLE
Disable building current.sqlite every night, for now.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -13,7 +13,9 @@ import org.khanacademy.Setup;
 
 new Setup(steps
 
-).addCronSchedule("H 21 * * *"
+// TODO(csilvers): re-enable this cronjob after building current.sqlite
+// has moved entirely to Go, including fetching the content data.
+//).addCronSchedule("H 21 * * *"
 
 ).addStringParam(
     "SNAPSHOT_NAMES",


### PR DESCRIPTION
## Summary:
We are going to be turning off the FMS in python, and getting rid of a
lot of the routes that dev/dev_appserver/create_user_interactions.py
is calling.  While this is all in flux, let's just keep current.sqlite
fixed in place.  We can restart it again once all the relevant
functionality is moved to Go + graphql (+ gcs).

Note that I'll have to turn off the cron via the jenkins UI as well.
But I turn it off here too so the UI changes will "stick".

Issue: https://khanacademy.atlassian.net/browse/INFRA-8358

## Test plan:
None