### PR TITLE
FEI-4867: Only run Python/Selenium tests when the tests are retried

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -603,10 +603,22 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
 
       try {
          stage("Running smoketests") {
-            parallel([
-               "run-tests": { runTests(); },
-               "test-lambdacli": { runLambda(); },
-            ]);
+            // In case we are retrying smoke tests, we should only run the
+            // Python/Selenium tests.  
+            // NOTE: `custom` is a special type that allow us to run a subset of
+            // tests. This happens when:  
+            // a) A deployer uses the `retry-xx-smoke-tests` command or  
+            // b) when this job is triggered from the Jenkins UI and we only run
+            // a subset of tests.
+            if (params.TEST_TYPE == "custom") {
+               runTests();
+            // Otherwise, run Python/Selenium tests + Cypress tests in parallel.
+            } else {
+               parallel([
+                  "run-tests": { runTests(); },
+                  "test-lambdacli": { runLambda(); },
+               ]);
+            }
          }
       } finally {
          // If we determined there were no tests to run, we should skip 

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -604,7 +604,9 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
       try {
          stage("Running smoketests") {
             // In case we are retrying smoke tests, we should only run the
-            // Python/Selenium tests.  
+            // Python/Selenium tests. We don't have to run the Cypress tests
+            // because the results from the Python tests are completely
+            // unrelated to the Cypress tests.   
             // NOTE: `custom` is a special type that allow us to run a subset of
             // tests. This happens when:  
             // a) A deployer uses the `retry-xx-smoke-tests` command or  


### PR DESCRIPTION
## Summary:

We are currently running Python/Selenium (Py/Sel) and Cypress/LambdaTest (Cy/LT) tests in
parallel. This happens everytime the `e2e-test` job is triggered.

While debugging some Cypress/LambdaTest test builds I noticed that the Cy/LT
tests are also triggered when we retry the Py/Sel tests in Slack (via
`buildmaster`).

This change attempts to run only Py/Sel tests when a set of Python e2e tests
fail, and prevent running Cy/LT builds that are not related to this retry.

Issue: FEI-4867

## Test plan:

In deployments, verify that the next time someone retries e2e tests, these don't
retry a LambdaTest build (or spin up a new `e2e-test-cypress` job).