### PR TITLE
Update e2e-test-cypress build name

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -74,6 +74,11 @@ Defaults to GIT_REVISION.""",
 
 ).apply()
 
+// Override the build name by the info that is passed in (from buildmaster).
+REVISION_DESCRIPTION = params.REVISION_DESCRIPTION ?: params.GIT_REVISION;
+currentBuild.displayName = ("${currentBuild.displayName} " +
+                            "(${REVISION_DESCRIPTION})");
+
 // We use the build name as a unique identifier for user notifications. 
 BUILD_NAME = "build e2e-cypress-test #${env.BUILD_NUMBER} (${params.URL}: ${params.REVISION_DESCRIPTION})"
 


### PR DESCRIPTION
## Summary:

While taking a look at the e2e-test-cypress job, I noticed that we are not
assigning a more meaninful name to the job.

This change intends to replicate what we do in `e2e-test` so both jobs
(Python/Selenium and Cypresss) have a similar name, so that makes it easy to
identify related builds.

Issue: XXX-XXXX

## Test plan:

- Navigated to the `e2e-test-cypress` Jenkins job page.  
- Clicked on the last job that succeeded.  
- On the sidebar, clicked on the `Replay` button, and added the changes
introduced in this PR.  
- Verified that the build name changed to something more descriptive.

https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/5691/