### PR TITLE
Stop turning old webapp branches into tags

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -113,34 +113,6 @@ clean_invalid_branches() {
 }
 
 
-# Turn branches that haven't been worked on a for a while -- like, 6
-# months -- into tags.  No content is deleted, but if you ever wanted to
-# continue working on that branch again you'd need to recreate it in
-# git. The reason we bother is that phabricator daemons do `git branch
-# --contains` which gets very slow when there are a lot of branches.
-turn_old_branches_into_tags() {
-    (
-        cd webapp
-        echo "Turning old branches into tags in `pwd`"
-
-        git fetch --prune --prune-tags origin
-        six_months_ago=`date +%s -d "-6 months"`
-        # This pattern-match should be good for another 83 years or so!
-        git for-each-ref --format='%(refname:strip=3) %(authordate:unix)' \
-                         'refs/remotes/origin/*' \
-        | while read branch date; do
-            if [ "$date" -lt "$six_months_ago" ]; then
-                echo "Turning '$branch' from a branch into a tag"
-                # This copies the branch to a tag and then deletes the
-                # branch, but *only* if the copy succeeded.
-                git push origin "origin/$branch:refs/tags/$branch" \
-                    && git push origin ":refs/heads/$branch"
-            fi
-        done
-    )
-}
-
-
 # Explicitly run `gc` on every workspace.  This causes us to repack
 # all our objects using the "alternates" directory, which saves a
 # lot of space.


### PR DESCRIPTION
## Summary:
This PR removes the weekly maintenance function that turns old webapp branches
into tags (old branches are branches that haven't been updated in more than 6
months). We started doing this because `git branch --contains`, which is used
by phabricator, is really slow when there are a lot of branches. The downside
of turning branches into tags is that the branch names become unusable; tags
can be deleted locally, but they're recreated by various automated processes
that push to webapp. Conflicting tag and branch names result in the error
`warning: refname '<branch-name>' is ambiguous`. We no longer use phabricator,
so old branches are no longer a problem (we think).

Issue: https://khanacademy.slack.com/archives/C013ANU53LK/p1671746937855749

## Test plan:
Before the change I ran:
```
./weekly-maintenance.sh --list
```
which output:
```
clean_docker
clean_publish_worker
clean_genfiles
compress_jenkins_logs
clean_invalid_branches
turn_old_branches_into_tags
gc_all_repos
clean_ka_translations
clean_graphql_gateway_schemas
backup_network_config
clean_unused_graphql_safelist_queries
svgcrush
pngcrush
clean_package_files
update_caniuse
```

After the change I ran the same command and the output was:
```
clean_docker
clean_publish_worker
clean_genfiles
compress_jenkins_logs
clean_invalid_branches
gc_all_repos
clean_ka_translations
clean_graphql_gateway_schemas
backup_network_config
clean_unused_graphql_safelist_queries
svgcrush
pngcrush
clean_package_files
update_caniuse
```