### PR TITLE
FEI-4883: Notify Cypress e2ed test failures to Slack

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -484,7 +484,7 @@ def runLambda(){
    // In case the main provider is down, shift a build-job to 'e2e-test-cypress-backup'
    build(job: 'e2e-test-cypress',
           parameters: [
-             string(name: 'SLACK_CHANNEL', value: "#cypress-testing"),
+             string(name: 'SLACK_CHANNEL', value: params.SLACK_CHANNEL),
              string(name: 'REVISION_DESCRIPTION', value: REVISION_DESCRIPTION),
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -485,6 +485,7 @@ def runLambda(){
    build(job: 'e2e-test-cypress',
           parameters: [
              string(name: 'SLACK_CHANNEL', value: params.SLACK_CHANNEL),
+             string(name: 'SLACK_THREAD', value: params.SLACK_THREAD),
              string(name: 'REVISION_DESCRIPTION', value: REVISION_DESCRIPTION),
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),


### PR DESCRIPTION
## Summary:
Ported the logic that we use in the default e2e-test job to notify
failures to Slack using the current Python/Selenium framework.

In the Cypress case, we created a script in `webapp`
(`notify-e2e-results.js`) to be able to replicate the way we send Slack
messages about the e2e test results (for both SUCCESS and FAILURE).

This new script also uses a different Slack wrapper for NodeJS that was
created in the `webapp` repo.

**NOTE:** For more info about the logic created for the JS/Cypress
version of this script, you can take a look at this PR:
https://github.com/Khan/webapp/pull/10867

Issue: FEI-4883

## Test Plan:

1. Navigated to https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/.
2. Clicked on any of the last runs (e.g https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/6343/).
3. Clicked on the `Replay` link.
4. In the `Main Script` textarea, I replaced the contents of that with
   the contents of the `e2e-test-cypress.groovy` file in this PR.
5. Clicked on the `Run` button.
6. Verified that the a Slack notification with the Cypress e2e results
   was sent to a particular thread that I used for testing.

https://khanacademy.slack.com/archives/C096UP7D0/p1673287190526359

Also confirmed that the results were sent to the #cypress-logs-deploys
channel and to my Slack handle (via Direct Message).

**NOTE:** After this is merged, all the test results will be also sent
to the `#qa-log` channel, and only the failures will be sent to the
`#dev-support-log` channel.