### PR TITLE
FEI-4883.2: E2E Cypress - Tidy up jenkins job

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -55,7 +55,18 @@ Defaults to GIT_REVISION.""",
    """How many worker machines to use. Max available is 20.""",
    "20"
 
-).addStringParam(
+)
+.addBooleanParam(
+   "USE_FIRSTINQUEUE_WORKERS",
+   """If true, use the jenkins workers that are set aside for the
+currently active deploy.  Obviously, this should only be set if you
+are, indeed, the currently active deploy.  We reserve these machines
+so the currently active deploy never has to wait for smoketest workers
+to spin up.""",
+   false
+
+)
+.addStringParam(
    "TEST_RETRIES",
    """How many retry attempts to use. By default is 3.""",
    "3"
@@ -89,6 +100,10 @@ DEPLOYER_USER = params.DEPLOYER_USERNAME.replace("@", "")
 // GIT_SHA1 is the sha1 for GIT_REVISION.
 GIT_SHA1 = null;
 
+// We have a dedicated set of workers for the second smoke test.
+WORKER_TYPE = (params.USE_FIRSTINQUEUE_WORKERS
+               ? 'ka-firstinqueue-ec2' : 'ka-test-ec2');
+
 def _setupWebapp() {
    GIT_SHA1 = kaGit.resolveCommitish("git@github.com:Khan/webapp",
                                         params.GIT_REVISION);
@@ -96,11 +111,11 @@ def _setupWebapp() {
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", GIT_SHA1);
 
    dir("webapp/services/static") {
-      sh("yarn install");
+      sh("yarn install --frozen-lockfile");
    }
 }
 
-def runLamdaTest() {
+def runLambdaTest() {
    // We need login creds for LambdaTest Cli
    def lt_username = sh(script: """\
       keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
@@ -226,20 +241,19 @@ def analyzeResults() {
 }
 
 
-onWorker("ka-test-ec2", '6h') {
+onWorker(WORKER_TYPE, '5h') {     // timeout
    notify([slack: [channel: params.SLACK_CHANNEL,
+                   thread: params.SLACK_THREAD,
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
-                   extraText : "Hey ${DEPLOYER_USER} ${BUILD_NAME} " +
-                   "FAILED (<https://automation.lambdatest.com/logs/|Open>)",
-                   when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
+                   when: ['FAILURE', 'UNSTABLE']]]) {
       stage("Sync webapp") {
          _setupWebapp();
       }
 
       try {
          stage("Run e2e tests") {
-            runLamdaTest();
+            runLambdaTest();
             
          }
       } finally {

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -490,6 +490,7 @@ def runLambda(){
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),
              string(name: 'NUM_WORKER_MACHINES', value: params.NUM_WORKER_MACHINES),
+             string(name: 'USE_FIRSTINQUEUE_WORKERS', value: params.USE_FIRSTINQUEUE_WORKERS),
              string(name: 'TEST_RETRIES', value: "3"),
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
             // It takes about 5 minutes to run all the Cypress e2e tests when


### PR DESCRIPTION
## Summary:
Making some slight changes to make it look closer to the existing python
e2e job.

- Removed the option to notify if the `e2e-test-cypress` job is aborted.
- Simplified the Slack message on this repo if the job returns a failure
  or is unstable.
- Included the workers logic used in the regular `e2e-test` job to make
  sure this job has the right priority.

Issue: FEI-4883

## Test plan:

1. Navigated to https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/.
2. Clicked on any of the last runs (e.g https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/6343/).
3. Clicked on the `Replay` link.
4. In the `Main Script` textarea, I replaced the contents of that with
   the contents of the `e2e-test-cypress.groovy` file in this PR.
5. Clicked on the `Run` button.
6. Verified that the new job succeeded: https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/6431/.
6. Verified that the a Slack notification with the Cypress e2e results
   was sent to the #cypress-logs-deploys channel.

https://khanacademy.slack.com/archives/C04FLNZ88D9/p1673536345273649