### PR TITLE
[fix] FEI-4883.2: E2E Cypress - Tidy up and fix issues

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -55,7 +55,18 @@ Defaults to GIT_REVISION.""",
    """How many worker machines to use. Max available is 20.""",
    "20"
 
-).addStringParam(
+)
+.addBooleanParam(
+   "USE_FIRSTINQUEUE_WORKERS",
+   """If true, use the jenkins workers that are set aside for the
+currently active deploy.  Obviously, this should only be set if you
+are, indeed, the currently active deploy.  We reserve these machines
+so the currently active deploy never has to wait for smoketest workers
+to spin up.""",
+   false
+
+)
+.addStringParam(
    "TEST_RETRIES",
    """How many retry attempts to use. By default is 3.""",
    "3"
@@ -89,6 +100,10 @@ DEPLOYER_USER = params.DEPLOYER_USERNAME.replace("@", "")
 // GIT_SHA1 is the sha1 for GIT_REVISION.
 GIT_SHA1 = null;
 
+// We have a dedicated set of workers for the second smoke test.
+WORKER_TYPE = (params.USE_FIRSTINQUEUE_WORKERS
+               ? 'ka-firstinqueue-ec2' : 'ka-test-ec2');
+
 def _setupWebapp() {
    GIT_SHA1 = kaGit.resolveCommitish("git@github.com:Khan/webapp",
                                         params.GIT_REVISION);
@@ -96,11 +111,11 @@ def _setupWebapp() {
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", GIT_SHA1);
 
    dir("webapp/services/static") {
-      sh("yarn install");
+      sh("yarn install --frozen-lockfile");
    }
 }
 
-def runLamdaTest() {
+def runLambdaTest() {
    // We need login creds for LambdaTest Cli
    def lt_username = sh(script: """\
       keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
@@ -226,20 +241,19 @@ def analyzeResults() {
 }
 
 
-onWorker("ka-test-ec2", '6h') {
+onWorker(WORKER_TYPE, '5h') {     // timeout
    notify([slack: [channel: params.SLACK_CHANNEL,
+                   thread: params.SLACK_THREAD,
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
-                   extraText : "Hey ${DEPLOYER_USER} ${BUILD_NAME} " +
-                   "FAILED (<https://automation.lambdatest.com/logs/|Open>)",
-                   when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
+                   when: ['FAILURE', 'UNSTABLE']]]) {
       stage("Sync webapp") {
          _setupWebapp();
       }
 
       try {
          stage("Run e2e tests") {
-            runLamdaTest();
+            runLambdaTest();
             
          }
       } finally {

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -490,6 +490,7 @@ def runLambda(){
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),
              string(name: 'NUM_WORKER_MACHINES', value: params.NUM_WORKER_MACHINES),
+             string(name: 'USE_FIRSTINQUEUE_WORKERS', value: params.USE_FIRSTINQUEUE_WORKERS),
              string(name: 'TEST_RETRIES', value: "3"),
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
             // It takes about 5 minutes to run all the Cypress e2e tests when

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -490,7 +490,7 @@ def runLambda(){
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),
              string(name: 'NUM_WORKER_MACHINES', value: params.NUM_WORKER_MACHINES),
-             string(name: 'USE_FIRSTINQUEUE_WORKERS', value: params.USE_FIRSTINQUEUE_WORKERS),
+             booleanParam(name: 'USE_FIRSTINQUEUE_WORKERS', value: params.USE_FIRSTINQUEUE_WORKERS),
              string(name: 'TEST_RETRIES', value: "3"),
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
             // It takes about 5 minutes to run all the Cypress e2e tests when


### PR DESCRIPTION
## Summary:
Re-introduces the changes added in #78, but fixes an issue that was
introduced in the `e2e-test.groovy` file.

The issue was that I didn't properly pass the value of
`USE_FIRSTINQUEUE_WORKERS` as a `boolean`, and instead this was being
passed as a `string`.

This caused the smoke tests job to fail, as the `e2e-test.groovy` file threw
the following error:

https://jenkins.khanacademy.org/job/deploy/job/e2e-test/44947/execution/node/71/

```
java.lang.ClassCastException: hudson.model.StringParameterValue.value expects class java.lang.String but received class java.lang.Boolean
	at org.jenkinsci.plugins.structs.describable.DescribableModel.coerce(DescribableModel.java:492)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.buildArguments(DescribableModel.java:409)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.instantiate(DescribableModel.java:329)
Caused: java.lang.IllegalArgumentException: Could not instantiate {name=USE_FIRSTINQUEUE_WORKERS, value=true} for hudson.model.StringParameterValue
```

Issue: FEI-4883

Test plan:

Land these changes and attempt a deploy to verify that both the
`e2e-test` and `e2e-test-cypress` jobs work as expected.