### PR TITLE
Allow jenkins to update index/queue/pubsub.yaml outside deploy_to_gae.py.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -437,7 +437,7 @@ def deployIndexYaml() {
 
 // This should be called from within a node().
 def deployQueueYaml() {
-   if (!("queue.yaml" in SERVICES)) {
+   if (!("queue_yaml" in SERVICES)) {
       return;
    }
    withSecrets() {    // TODO(csilvers): do we actually need Python secrets?
@@ -449,7 +449,7 @@ def deployQueueYaml() {
 
 // This should be called from within a node().
 def deployPubsubYaml() {
-   if (!("pubsub.yaml" in SERVICES)) {
+   if (!("pubsub_yaml" in SERVICES)) {
       return;
    }
    withSecrets() {    // TODO(csilvers): do we actually need Python secrets?
@@ -457,6 +457,36 @@ def deployPubsubYaml() {
          exec(["deploy/upload_pubsub.py", "create", NEW_VERSION]);
       }
    }
+}
+
+// This should be called from within a node().
+def deployDispatchYaml() {
+   if (!("dispatch_yaml" in SERVICES)) {
+      return;
+   }
+
+   // We do not deploy dispatch.yaml in build-webapp.groovy because
+   // dispatch.yaml is not an "additive" yaml file like index.yaml:
+   // uploading this removes old dispatch rules in addition to adding
+   // new ones.  So it's not safe to do until set-default time.
+   // Thus, dispatch.yaml is handled by deploy-webapp.groovy, not here.
+   // This function is included just for documentation purposes.
+   return;
+}
+
+// This should be called from within a node().
+def deployCronYaml() {
+   if (!("cron_yaml" in SERVICES)) {
+      return;
+   }
+
+   // We do not deploy ka_cron.yaml in build-webapp.groovy because
+   // cron.yaml is not an "additive" yaml file like index.yaml:
+   // uploading this removes old cron jobs in addition to adding
+   // new ones.  So it's not safe to do until set-default time.
+   // Thus, ka_cron.yaml is handled by deploy-webapp.groovy, not here.
+   // This function is included just for documentation purposes.
+   return;
 }
 
 // This should be called from within a node().
@@ -580,6 +610,8 @@ def deployAndReport() {
                   "deploy-index-yaml": { deployIndexYaml(); },
                   "deploy-queue-yaml": { deployQueueYaml(); },
                   "deploy-pubsub-yaml": { deployPubsubYaml(); },
+                  "deploy-dispatch-yaml": { deployDispatchYaml(); },
+                  "deploy-cron-yaml": { deployCronYaml(); },
                   "failFast": true];
       for (service in SERVICES) {
          // 'dynamic', 'static', and 'dataflow-batch' services are a bit more
@@ -591,7 +623,8 @@ def deployAndReport() {
          if (!(service in [
                'dynamic', 'static',
                'course-editing', 'dataflow-batch',
-               'index_yaml', 'queue_yaml', 'pubsub_yaml'])) {
+               'index_yaml', 'queue_yaml', 'pubsub_yaml',
+               'dispatch_yaml', 'cron_yaml'])) {
             // We need to define a new variable so that we don't pass the loop
             // variable into the closure: it may have changed before the
             // closure executes.  See for example

--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -71,10 +71,9 @@ specify "dynamic,static" to force a full deploy to GAE and GCS.</p>
 <ul>
   <li> <b>dynamic</b>: Upload dynamic (e.g. py) files to GAE. </li>
   <li> <b>static</b>: Upload static (e.g. js) files to GCS. </li>
-  <li> <b>kotlin-routes</b>: webapp's services/kotlin-routes/. </li>
-  <li> <b>course-editing</b>: webapp's services/course-editing/. </li>
   <li> <b>donations</b>: webapp's services/donations/. </li>
-  <li> <b>index.yaml</b>: upload index.yaml to GAE. </li>
+  <li> <b>course-editing</b>: webapp's services/course-editing/. </li>
+  <li> <b>index_yaml</b>: upload index.yaml to GAE. </li>
 </ul>
 
 <p>You can specify the empty string to deploy to none of these services, like
@@ -428,7 +427,7 @@ def deployToGCS() {
 
 // This should be called from within a node().
 def deployIndexYaml() {
-   if (!("index.yaml" in SERVICES)) {
+   if (!("index_yaml" in SERVICES)) {
       return;
    }
    // Apparently we need APPENGINE_RUNTIME= to get the imports working right.
@@ -534,7 +533,7 @@ def deployToService(service) {
 // this, and let kotlin services default to the shared deployToService again.
 def deployToKotlinServicesAndDataflow() {
    for (service in SERVICES) {
-      if (service in ['course-editing', 'kotlin-routes']) {
+      if (service in ['course-editing']) {
          deployToService(service);
       }
       if (service == 'dataflow-batch') {
@@ -578,9 +577,9 @@ def deployAndReport() {
                      deployToKotlinServicesAndDataflow();
                   },
                   "deploy-to-gateway-config": { deployToGatewayConfig(); },
-                  "deploy-index.yaml": { deployIndexYaml(); },
-                  "deploy-queue.yaml": { deployQueueYaml(); },
-                  "deploy-pubsub.yaml": { deployPubsubYaml(); },
+                  "deploy-index-yaml": { deployIndexYaml(); },
+                  "deploy-queue-yaml": { deployQueueYaml(); },
+                  "deploy-pubsub-yaml": { deployPubsubYaml(); },
                   "failFast": true];
       for (service in SERVICES) {
          // 'dynamic', 'static', and 'dataflow-batch' services are a bit more
@@ -591,8 +590,8 @@ def deployAndReport() {
          // deployments are bundled in deployToKotlinServicesAndDataflow().
          if (!(service in [
                'dynamic', 'static',
-               'course-editing', 'kotlin-routes', 'dataflow-batch',
-               'index.yaml', 'queue.yaml', 'pubsub.yaml'])) {
+               'course-editing', 'dataflow-batch',
+               'index_yaml', 'queue_yaml', 'pubsub_yaml'])) {
             // We need to define a new variable so that we don't pass the loop
             // variable into the closure: it may have changed before the
             // closure executes.  See for example

--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -436,6 +436,7 @@ def deployIndexYaml() {
          "gcloud", "--project=khan-academy", "app", "deploy", "index.yaml"]);
 }
 
+// This should be called from within a node().
 def deployQueueYaml() {
    if (!("queue.yaml" in SERVICES)) {
       return;
@@ -447,6 +448,7 @@ def deployQueueYaml() {
     }
 }
 
+// This should be called from within a node().
 def deployPubsubYaml() {
    if (!("pubsub.yaml" in SERVICES)) {
       return;


### PR DESCRIPTION
## Summary:
Historically, when there have been changes to index.yaml, queue.yaml,
or pubsub.yaml, that's prompted a deploy of the default module (even
if the python code itself hasn't changed!), and deploy_to_gae.py would
update those yaml files in addition to updating the default module.

Now that python is going away, we want to separate those
responsibilities.  The plan is to create three new pseudo-services,
index.yaml, queue.yaml, and pubsub.yaml.  And should_deploy.py can say
we need to deploy to those services.  Jenkins notices this and uploads
the relevant yaml file to GAE.

This is the jenkins part of things: it notices when the new
pseudo-services are being deployed and uploads the yaml files.  Once
this is tested, I will change should_deploy.py to emit these
pseudo-services when appropriate, and change deploy_to_gae.py to no
longer try to upload to them.

Issue: INFRA-XXXX

## Test plan:
I ran `groovy jobs/build-webapp.groovy` with no new failures.  But my
main test will be to do a deploy after this is in, like so:
```
sun: queue csilvers (SERVICES=queue.yaml,pubsub.yaml,index.yaml)
```
and make sure it runs the upload commands with success.