### PR TITLE
Add one default worker for priming Cypress e2e tests

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -71,10 +71,12 @@ buildmaster, to the 'thread_ts' or 'timestamp' value returned by the Slack
 API.""",
     ""
 
+// NOTE: We remove one worker from the default as it is used by the
+// e2e-test-cypress job.
 ).addStringParam(
    "NUM_WORKER_MACHINES",
    """How many worker machines to use.""",
-   onWorker.defaultNumTestWorkerMachines().toString()
+   (onWorker.defaultNumTestWorkerMachines() - 1).toString()
 
 ).addBooleanParam(
    "USE_FIRSTINQUEUE_WORKERS",
@@ -294,15 +296,15 @@ def runTestServer() {
       }
 
       // Determine if we actually need to run any tests at all
-      // TODO(dbraley): This process takes a few seconds to run, and is done 
+      // TODO(dbraley): This process takes a few seconds to run, and is done
       //  again by the actual server run a bit later in this method. We should
-      //  make this faster, or at least able to reuse the test list we've 
+      //  make this faster, or at least able to reuse the test list we've
       //  already calculated.
       tests = exec.outputOf(["testing/runtests_server.py", "-n"] + runSmokeTestsArgs + ["."]);
 
-      // The runtests_server.py script with -n outputs all tests to run of 
-      // various types. We only need to worry about smoke tests, which are 
-      // also the last section, so grab everything after the header. If it's 
+      // The runtests_server.py script with -n outputs all tests to run of
+      // various types. We only need to worry about smoke tests, which are
+      // also the last section, so grab everything after the header. If it's
       // empty, there are no tests to run.
       e2eTests = tests.substring(tests.lastIndexOf("SMOKE TESTS:") + "SMOKE TESTS:".length())
       // An empty line indicates the end of the section (if found)
@@ -489,13 +491,13 @@ def runLambda(){
              string(name: 'REVISION_DESCRIPTION', value: REVISION_DESCRIPTION),
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),
-             string(name: 'NUM_WORKER_MACHINES', value: params.NUM_WORKER_MACHINES),
+             string(name: 'NUM_WORKER_MACHINES', value: "30"),
              booleanParam(name: 'USE_FIRSTINQUEUE_WORKERS', value: params.USE_FIRSTINQUEUE_WORKERS),
-             string(name: 'TEST_RETRIES', value: "3"),
+             string(name: 'TEST_RETRIES', value: "4"),
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
             // It takes about 5 minutes to run all the Cypress e2e tests when
             // using the default of 20 workers. This build is running in parallel
-            // with runTests(). During this test run we don't want to disturb our 
+            // with runTests(). During this test run we don't want to disturb our
             // mainstream e2e pipeline, so set propagate to false.
           ],
           propagate: false,
@@ -608,10 +610,10 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
             // In case we are retrying smoke tests, we should only run the
             // Python/Selenium tests. We don't have to run the Cypress tests
             // because the results from the Python tests are completely
-            // unrelated to the Cypress tests.   
+            // unrelated to the Cypress tests.
             // NOTE: `custom` is a special type that allow us to run a subset of
-            // tests. This happens when:  
-            // a) A deployer uses the `retry-xx-smoke-tests` command or  
+            // tests. This happens when:
+            // a) A deployer uses the `retry-xx-smoke-tests` command or
             // b) when this job is triggered from the Jenkins UI and we only run
             // a subset of tests.
             if (params.TEST_TYPE == "custom") {
@@ -625,7 +627,7 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
             }
          }
       } finally {
-         // If we determined there were no tests to run, we should skip 
+         // If we determined there were no tests to run, we should skip
          // analysis since it fails if there are no test results.
          if (skipTestAnalysis) {
             echo("Skipping Analysis - No tests run")

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -71,12 +71,10 @@ buildmaster, to the 'thread_ts' or 'timestamp' value returned by the Slack
 API.""",
     ""
 
-// NOTE: We remove one worker from the default as it is used by the
-// e2e-test-cypress job.
 ).addStringParam(
    "NUM_WORKER_MACHINES",
    """How many worker machines to use.""",
-   (onWorker.defaultNumTestWorkerMachines() - 1).toString()
+   onWorker.defaultNumTestWorkerMachines().toString()
 
 ).addBooleanParam(
    "USE_FIRSTINQUEUE_WORKERS",
@@ -491,7 +489,6 @@ def runLambda(){
              string(name: 'REVISION_DESCRIPTION', value: REVISION_DESCRIPTION),
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),
-             string(name: 'NUM_WORKER_MACHINES', value: "30"),
              booleanParam(name: 'USE_FIRSTINQUEUE_WORKERS', value: params.USE_FIRSTINQUEUE_WORKERS),
              string(name: 'TEST_RETRIES', value: "4"),
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -490,13 +490,12 @@ def runLambda(){
              string(name: 'DEPLOYER_USERNAME', value: params.DEPLOYER_USERNAME),
              string(name: 'URL', value: E2E_URL),
              booleanParam(name: 'USE_FIRSTINQUEUE_WORKERS', value: params.USE_FIRSTINQUEUE_WORKERS),
-             string(name: 'TEST_RETRIES', value: "4"),
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
-            // It takes about 5 minutes to run all the Cypress e2e tests when
-            // using the default of 20 workers. This build is running in parallel
-            // with runTests(). During this test run we don't want to disturb our
-            // mainstream e2e pipeline, so set propagate to false.
           ],
+          // It takes about 5 minutes to run all the Cypress e2e tests when
+          // using the default of 20 workers. This build is running in parallel
+          // with runTests(). During this test run we don't want to disturb our
+          // mainstream e2e pipeline, so set propagate to false.
           propagate: false,
           // The pipeline will NOT wait for this job to complete to avoid
           // blocking the main pipeline (e2e tests).

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -86,8 +86,7 @@ API.""", ""
    "NUM_WORKER_MACHINES",
     """How many worker machines to use.""",
     // We divide by 2 because we use 2 clients per worker by default.
-    // We subtract 1 because we reserve one machine for Cypress e2e tests.
-    ((onWorker.defaultNumTestWorkerMachines() - 1) / 2).toString()
+    (onWorker.defaultNumTestWorkerMachines() / 2).toString()
 
 ).addStringParam(
    "CLIENTS_PER_WORKER",

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -86,7 +86,8 @@ API.""", ""
    "NUM_WORKER_MACHINES",
     """How many worker machines to use.""",
     // We divide by 2 because we use 2 clients per worker by default.
-    (onWorker.defaultNumTestWorkerMachines() / 2).toString()
+    // We subtract 1 because we reserve one machine for Cypress e2e tests.
+    ((onWorker.defaultNumTestWorkerMachines() - 1) / 2).toString()
 
 ).addStringParam(
    "CLIENTS_PER_WORKER",

--- a/vars/onWorker.groovy
+++ b/vars/onWorker.groovy
@@ -3,19 +3,11 @@
 //import vars.withTimeout
 //import vars.withVirtualenv
 
-
-// NOTE: We currently use the following workers in e2e-related jobs in parallel:
-// a) 20 workers for the `e2e-test` job.
-// b) 1 worker for the `e2e-test-cypress` job.
-// TODO(FEI-4888): Modify this value once we turn off the Python e2e tests. We
-// could probably reduce this to the number of workers we use in the
-// `webapp-test` job.
-
 // How many test-workers we run in parallel, by default. This no longer needs to
 // be consistent across jobs, but most jobs using the ka-test-ec2 workers use it
 // by default.
 def defaultNumTestWorkerMachines() {
-   return 21;
+   return 20;
 }
 
 // label is the label of the node.  It should be one of the worker labels

--- a/vars/onWorker.groovy
+++ b/vars/onWorker.groovy
@@ -3,11 +3,19 @@
 //import vars.withTimeout
 //import vars.withVirtualenv
 
-// How many test-workers we run in parallel, by default.
-// This no longer needs to be consistent across jobs, but
-// most jobs using the ka-test-ec2 workers use it by default.
+
+// NOTE: We currently use the following workers in e2e-related jobs in parallel:
+// a) 20 workers for the `e2e-test` job.
+// b) 1 worker for the `e2e-test-cypress` job.
+// TODO(FEI-4888): Modify this value once we turn off the Python e2e tests. We
+// could probably reduce this to the number of workers we use in the
+// `webapp-test` job.
+
+// How many test-workers we run in parallel, by default. This no longer needs to
+// be consistent across jobs, but most jobs using the ka-test-ec2 workers use it
+// by default.
 def defaultNumTestWorkerMachines() {
-   return 20;
+   return 21;
 }
 
 // label is the label of the node.  It should be one of the worker labels


### PR DESCRIPTION
## Summary:
We are currently priming 20 workers that are used by the Python/Selenium
e2e tests. We noticed that the Cypress e2e tests are taking ~2 minutes
before a worker becomes available so the job starts running and this is
due to the Python e2e tests taking up all the available workers.

This PR adds one default worker that will be used by the Cypress e2e
tests so that both `e2e-test` and `e2e-test-cypress` jobs can start
around the same time.

Note that Python and Cypress e2e tests are run in parallel, so we need
to prime+run then at the same time.

Issue: XXX-XXXX

## Test plan:

I've tested all the Jenkins jobs that are affected by this change using
the Replay feature. I checked that these changes didn't introduce any
regression:


1. Ran the `firstinqueue-priming` job first to prime the machines: https://jenkins.khanacademy.org/job/deploy/job/firstinqueue-priming/2761/console

2. Ran an `e2e-test `replay: https://jenkins.khanacademy.org/job/deploy/job/e2e-test/45423/console
3. This originated a new `e2e-test-cypress` job: https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/6912/console

I compared the `e2e-test` and the `e2e-test-cypress` jobs and noticed that the difference of start times when down to `~15 seconds`.


### Results
Current job (120 seconds) - PR changes (15 seconds) = `1m 45s gains`.  This means that the Cypress e2e job should finish around 1m 45s earlier than before.