### PR TITLE
Added work for creating cloud run tasks in jenkins

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -531,11 +531,8 @@ def uploadGraphqlSafelist() {
 def createCloudRunTags(){
    echo("Creating Cloud Run tags.")
    dir("webapp") {
-      try {
-         exec(["deploy/update_cloud_run_tags.py", NEW_VERSION]);
-      } catch (e) {
-         echo("Failed to wait for new version: ${e}");
-      }
+      exec(["deploy/update_cloud_run_tags.py", NEW_VERSION
+            "--modules_to_ignore", SERVICES.join(', ')]);
    }
 }
 
@@ -654,8 +651,10 @@ def deployAndReport() {
       }
       parallel(jobs);
 
-      createCloudRunTags();
-      uploadGraphqlSafelist();
+      parallel([
+         "create-cloud-run-tags": { createCloudRunTags(); },
+         "update-graphql-safelist": { uploadGraphqlSafelist(); }
+      ])
 
       _alert(alertMsgs.JUST_DEPLOYED,
              [deployUrl: DEPLOY_URL,

--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -531,11 +531,11 @@ def uploadGraphqlSafelist() {
 def createCloudRunTags(){
    echo("Creating Cloud Run tags.")
    dir("webapp") {
-            // Note: we do not update tags on the modules that we are deploying,
-            // because they get assigned their tag at deploy-time, so doing it
-            // here would be redundant (and would actually conflict).
-            exec(["deploy/update_cloud_run_tags.py", NEW_VERSION
-            "--modules_to_ignore", SERVICES.join(', ')]);
+      // Note: we do not update tags on the modules that we are deploying,
+      // because they get assigned their tag at deploy-time, so doing it
+      // here would be redundant (and would actually conflict).
+      exec(["deploy/update_cloud_run_tags.py", NEW_VERSION
+            "--modules_to_ignore", SERVICES.join(',')]);
    }
 }
 

--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -531,7 +531,10 @@ def uploadGraphqlSafelist() {
 def createCloudRunTags(){
    echo("Creating Cloud Run tags.")
    dir("webapp") {
-      exec(["deploy/update_cloud_run_tags.py", NEW_VERSION
+            // Note: we do not update tags on the modules that we are deploying,
+            // because they get assigned their tag at deploy-time, so doing it
+            // here would be redundant (and would actually conflict).
+            exec(["deploy/update_cloud_run_tags.py", NEW_VERSION
             "--modules_to_ignore", SERVICES.join(', ')]);
    }
 }

--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -528,6 +528,18 @@ def uploadGraphqlSafelist() {
 }
 
 
+def createCloudRunTags(){
+   echo("Creating Cloud Run tags.")
+   dir("webapp") {
+      try {
+         exec(["deploy/update_cloud_run_tags.py", NEW_VERSION]);
+      } catch (e) {
+         echo("Failed to wait for new version: ${e}");
+      }
+   }
+}
+
+
 // When we deploy a change to a service, it may change the overall federated
 // graphql schema. We store this overall schema in a version labeled json file
 // stored on GCS.
@@ -642,6 +654,7 @@ def deployAndReport() {
       }
       parallel(jobs);
 
+      createCloudRunTags();
       uploadGraphqlSafelist();
 
       _alert(alertMsgs.JUST_DEPLOYED,

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -285,11 +285,8 @@ def deployToGatewayConfig() {
 def createCloudRunTags(){
    echo("Creating Cloud Run tags.")
    dir("webapp") {
-      try {
-         exec(["deploy/update_cloud_run_tags.py", VERSION]);
-      } catch (e) {
-         echo("Failed to wait for new version: ${e}");
-      }
+      exec(["deploy/update_cloud_run_tags.py", VERSION,
+            "--modules_to_ignore", SERVICES.join(', ')]);
    }
 }
 

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -282,6 +282,17 @@ def deployToGatewayConfig() {
    }
 }
 
+def createCloudRunTags(){
+   echo("Creating Cloud Run tags.")
+   dir("webapp") {
+      try {
+         exec(["deploy/update_cloud_run_tags.py", VERSION]);
+      } catch (e) {
+         echo("Failed to wait for new version: ${e}");
+      }
+   }
+}
+
 // TODO(colin): these messaging functions are mostly duplicated from
 // deploy-webapp.groovy and deploy-history.groovy.  We should probably set up
 // an alertlib (or perhaps just slack messaging) wrapper, since similar
@@ -394,6 +405,8 @@ def deploy() {
       jobs["failFast"] = true;
 
       parallel(jobs);
+
+      createCloudRunTags();
 
       _sendSimpleInterpolatedMessage(
          alertMsgs.JUST_DEPLOYED.text,

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -285,8 +285,11 @@ def deployToGatewayConfig() {
 def createCloudRunTags(){
    echo("Creating Cloud Run tags.")
    dir("webapp") {
+      // Note: we do not update tags on the modules that we are deploying,
+      // because they get assigned their tag at deploy-time, so doing it
+      // here would be redundant (and would actually conflict).
       exec(["deploy/update_cloud_run_tags.py", VERSION,
-            "--modules_to_ignore", SERVICES.join(', ')]);
+            "--modules_to_ignore", SERVICES.join(',')]);
    }
 }
 


### PR DESCRIPTION
## Summary:
In order for Cloud Run services to handle traffic for versions that don't exist in Cloud Run we need to create traffic tags. These traffic tags is how we can send traffic to default revisions.  We need to do this when we build webapp and when we deploy znds.

Issue: https://khanacademy.atlassian.net/browse/INFRA-8963

## Test plan:
Im going to kick off a znd build for service-testbed and check the logs.