### PR TITLE
FEI-4923.2: Include Slack token in the lambdatest step

### DIFF
--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -146,7 +146,14 @@ def runLambdaTest() {
    dir('webapp/services/static') {
       withEnv(["LT_USERNAME=${lt_username}",
                "LT_ACCESS_KEY=${lt_access_key}"]) {
-         exec(runLambdaTestArgs);
+         // NOTE: We include this Slack token in case we need to notify to the
+         // FEI team when we are going to hit a `queue_timeout` error in the
+         // LambdaTest platform.
+         withCredentials([
+            string(credentialsId: "SLACK_BOT_TOKEN", variable: "SLACK_TOKEN")
+         ]) {
+            exec(runLambdaTestArgs);
+         }
       }
    }
 }

--- a/jobs/e2e-test-cypress.groovy
+++ b/jobs/e2e-test-cypress.groovy
@@ -146,7 +146,7 @@ def runLambdaTest() {
    dir('webapp/services/static') {
       withEnv(["LT_USERNAME=${lt_username}",
                "LT_ACCESS_KEY=${lt_access_key}"]) {
-         // NOTE: We include this Slack token in case we need to notify to the
+         // NOTE: We include this Slack token in case we need to notify the
          // FEI team when we are going to hit a `queue_timeout` error in the
          // LambdaTest platform.
          withCredentials([


### PR DESCRIPTION
## Summary:

We made some changes in https://github.com/Khan/webapp/pull/11664 to be able to
identify if the LambdaTest platform is going to hit queue timeout errors.

This happens when there are multiple builds in parallel, causing our e2e tests
to fail b/c there are no more available machines to run the tests.

This check was introduced in the `webapp` repo, and the only thing that we need
to do in Jenkins to support it is to include the Slack token so we can send a
notification to the FEI team in case we hit this queue timeout error.

Issue: FEI-4923

## Test plan:

Using replay, I verified that these changes worked fine:

https://jenkins.khanacademy.org/job/deploy/job/e2e-test-cypress/7050/console