### PR TITLE
Change most of our cron-based jenkins jobs to send to slack on success.

### DIFF
--- a/jobs/clean-queues.groovy
+++ b/jobs/clean-queues.groovy
@@ -37,7 +37,7 @@ onMaster('1h') {
    notify([slack: [channel: '#infrastructure',
                 sender: 'Mr Monkey',
                 emoji: ':monkey_face:',
-                when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
+                when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Deleting queues") {
          deleteQueues();
       }

--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -73,7 +73,7 @@ onMaster('2h') {
    notify([slack: [channel: params.SLACK_CHANNEL,
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
-                   when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
+                   when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Run script") {
          runScript();
       }


### PR DESCRIPTION
## Summary:
We had a problem where the `clean_queues` job deleted a taskqueue it
shouldn't have, and it took us a while to track down because nobody
left at the company even realized this job existed!

This PR tries to help with that a little by having most cron-based
jenkins jobs send to slack on success, rather than just on failure.
That way at least people will have a chance of knowing the job exists.

The only cron-jobs that I did not modify are `make-allcheck` and
`find-failing-taskqueue-tasks`, since they send to slack on success in
any case (as part of their job output); and `update-i18n-lite-videos`,
which pings `@cp-support` when it talks to slack, which we don't
want to do on success (it creates a ticket!)

Issue: https://khanacademy.atlassian.net/browse/INFRA-9008

## Test plan:
Fingers crossed