### PR TITLE
[🔥AUDIT🔥] Disable the clean-queues.groovy cronjob.

### DIFF
--- a/jobs/clean-queues.groovy
+++ b/jobs/clean-queues.groovy
@@ -14,10 +14,13 @@ import org.khanacademy.Setup;
 
 new Setup(steps
 
-).addCronSchedule(
-   // Run every Tuesday at 10am.  The time is arbitrary, but during business
-   // hours so we can fix things if they break.
-   '0 10 * * 2'
+// We've disabled this job until we can be sure it only deletes
+// queues it's supposed to.
+//
+// ).addCronSchedule(
+//    // Run every Tuesday at 10am.  The time is arbitrary, but during business
+//    // hours so we can fix things if they break.
+//    '0 10 * * 2'
 
 ).apply();
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We will no longer run it.  Amos already disabled this job via the UI,
but this change will make sure it doesn't come back again (until we
want it to).

The issue is the job deleted some queues that were still in use.  We
are being very careful with the code before turning this back on again
(if we ever do).

Issue: https://khanacademy.atlassian.net/browse/INFRA-9008

## Test plan:
None