### PR TITLE
Prune docker images before building publish-worker and translations-pipeline

### DIFF
--- a/jobs/build-publish-image.groovy
+++ b/jobs/build-publish-image.groovy
@@ -38,11 +38,11 @@ someone else's publish-deploy on purpose.""",
 currentBuild.displayName = "${currentBuild.displayName} (${params.GIT_REVISION})";
 
 def runScript() {
-   // Prune docker images before building if under 1.5GB of disk space.
-   sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
-
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
                           params.GIT_REVISION);
+
+   // Prune docker images before building if under 1.5GB of disk space.
+   sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
 
    dir("webapp") {
        if (params.VALIDATE_COMMIT) {

--- a/jobs/build-publish-image.groovy
+++ b/jobs/build-publish-image.groovy
@@ -38,6 +38,9 @@ someone else's publish-deploy on purpose.""",
 currentBuild.displayName = "${currentBuild.displayName} (${params.GIT_REVISION})";
 
 def runScript() {
+   // Prune docker images before building if under 1.5GB of disk space.
+   sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
+
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
                           params.GIT_REVISION);
 

--- a/jobs/update-translation-pipeline.groovy
+++ b/jobs/update-translation-pipeline.groovy
@@ -38,7 +38,10 @@ new docker image.""",
 currentBuild.displayName = "${currentBuild.displayName} (${params.GIT_REVISION})";
 
 def runScript() {
-   kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
+    // Prune docker images before building if under 1.5GB of disk space.
+    sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
+
+    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
                           params.GIT_REVISION);
 
     dir("webapp/services/content-editing/translation_pipeline") {

--- a/jobs/update-translation-pipeline.groovy
+++ b/jobs/update-translation-pipeline.groovy
@@ -38,11 +38,11 @@ new docker image.""",
 currentBuild.displayName = "${currentBuild.displayName} (${params.GIT_REVISION})";
 
 def runScript() {
-    // Prune docker images before building if under 1.5GB of disk space.
-    sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
-
     kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
                           params.GIT_REVISION);
+
+    // Prune docker images before building if under 1.5GB of disk space.
+    sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
 
     dir("webapp/services/content-editing/translation_pipeline") {
        exec(["make", "push", "ZND_NAME=${params.ZND_NAME}"]);


### PR DESCRIPTION
## Summary:
We keep running out of disk space on build workers, which then requires deleting
them. Instead, if we first prune images we can avoid this issue when building the
publish-worker and translatios-pipeline. Even if it takes a bit longer, since
they're not frequently built.

However, since `build-worker` is shared with `deploy-webapp`, `deploy-znd`, etc.
We need to ensure prunning Docker images is not going to slow down build other jobs!

Issue: https://khanacademy.slack.com/archives/C49296Q7P/p1679938601807059?thread_ts=1679706002.920919&cid=C49296Q7P

Test Plan:
 - Verify deploying webapp and ZND is not affected
 - Verify building images works for:
https://jenkins.khanacademy.org/job/deploy/job/update-translation-pipeline/build?delay=0sec
https://jenkins.khanacademy.org/job/deploy/job/build-publish-image/