### PR TITLE
Clean up potential bad github refs before fetching.

### DIFF
--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -179,10 +179,10 @@ def safeMergeFromMaster(dir, commitToMergeInto, submodules=[]) {
 
 
 // Merges multiple branches together into a single commit.
-// 
+//
 // Arguments:
 // - gitRevisions: string containing one or more branche names separated by "+"
-// - tagName: string to tag the resulting commit with.  We need to tag the 
+// - tagName: string to tag the resulting commit with.  We need to tag the
 //   result of the merge so git doesn't prune it.
 //
 // Notes:
@@ -199,6 +199,8 @@ def mergeBranches(gitRevisions, tagName) {
       // as you might think.
       exec(["git", "reset", "--hard"]);
    }
+   // Get rid of all old branches; if they were dangling they'd break fetch.
+   exec(["jenkins-jobs/safe_git.sh", "clean_branches", directory]);
    quickFetch("webapp");
    dir('webapp') {
       for (def i = 0; i < allBranches.size(); i++) {


### PR DESCRIPTION
## Summary:
Every so often, deploys will fail with a message like this, at
fetch-time:
> 11:40:01  fatal: bad object refs/heads/ai-guid-acts.prompt-updates

This is because there's a branch, in jenkin's webapp repo, named
ai-guid-acts.prompt-updates, but it points to a bad commit.  I'm not
100% sure how this can happen, but probably it's because the branch is
deleted/never-merged/forced-pushed, and then we do a gc, and now the
commit it was pointed to is gone.

In any case, this "dangling" branch causes `git fetch` to fail.

This PR attempts to deal with this by deleting all branches before a
`git fetch`, when it is safe to do so.  I'm conservative about the
places I do it: they're places where we clone a repo if it doesn't
exist, which is evidence these functions don't have any pre-conceived
notions of what branches might be around.  But they catch the places
that matter for the deploy process: merge-branches and safe-sync-to.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1680028939583289

## Test plan:
Fingers crossed!  I tried to do this in as safe a way possible, but
it's still a bit scary to automatically delete things.