### PR TITLE
Use "blobless" checkouts when cloning repos.

### DIFF
--- a/safe_git.sh
+++ b/safe_git.sh
@@ -174,7 +174,9 @@ _update_submodules() {
 
 # Clone the given repo if it doesn't already exist.
 # This is just like git clone, except we set up "alternates" to point
-# to a central repo.
+# to a central repo.  We also make it a "blobless" clone so we don't
+# fetch a bunch of history we're unlikely to care about.  See
+# https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
 # $1: repo to clone (a la sync_to)
 # $2: directory into which to clone it
 # $2: commit-ish to check out at.  Note that we don't do submodules
@@ -196,12 +198,12 @@ clone() {
             clean_branches "$repo_dir"
             ( cd "$repo_dir" && _fetch )
         else
-            timeout 60m git clone "$repo" "$repo_dir"
+            timeout 60m git clone --filter=blob:none "$repo" "$repo_dir"
         fi
         # Now clone locally as well.
         # TODO(csilvers): figure out how to use `git clone -s` but still
         # have our version point to the correct remote.
-        timeout 60m git clone "$repo" "$repo_workspace"
+        timeout 60m git clone --filter=blob:none "$repo" "$repo_workspace"
 
         cd "$repo_workspace"
         # This is the magic that makes all our repos share an "objects" dir.


### PR DESCRIPTION
## Summary:
"blobless" checkouts start with only the metadata (tree structure,
commit messages, etc) checked out.  Content is only checked out at
need, when doing `git checkout` or `git log -S` or anything else that
requires the actual content-blobs.

That can work really well for Jenkins jobs, which often don't need to
look at history at all.  The repos can be much smaller, and `git
fetch`s should be much faster as well (since there's less to fetch).
So this could speed up deploys somewhat.

This has a big advantage over shallow checkouts and other, older
alternatives in that no functionality breaks when using this (in
theory), some operations just might get slower because they need to
fetch blobs.  So it should be safe.

I'm not sure how blobless checkouts work with alternates, which we
also use.  But the test plan indicates it's ok, as far as I can tell.

Issue: https://khanacademy.slack.com/archives/C8Y4Q1E0J/p1679955211529959

## Test plan:
I waited until a weekend day where we had no jenkins jobs running, and
manually started a jenkins worker.  I ssh'ed to it and manually
deleted the workspace and the alternates directory, to force a full
re-clone.  I then ran a `webapp-test` job on `master`, and verified
that a) my jenkins worker ran some of the job, and b) it ran it correctly.