### PR TITLE
Add typecheck_test_client.sh to support TS

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -168,6 +168,7 @@ WORKER_TYPE = (params.MAX_SIZE in ["large", "huge"]
 //    things still work even if `done` is never set to true.
 TESTS = [
     [cmd: "testing/flow_test_client.sh -j1 <server>", done: false],
+    [cmd: "testing/typecheck_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/kotlin_test_client.sh -j1 <server>", oneAtATime: true, done: false],
     [cmd: "testing/runtests.py --quiet --jobs=1 --xml <server>", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> javascript", done: false],


### PR DESCRIPTION
## Summary:
This adds a new test client, `typecheck_test_client.sh` that basically will replace `flow_test_client.sh` once flow is replaced with TypeScript (TS) fully.

Issue: FEI-4961

## Test plan:
Land this and then rerun the job for https://github.com/Khan/webapp/pull/13083 to see that it works.