### PR TITLE
Fix publish worker and TAP jobs

### DIFF
--- a/jobs/build-publish-image.groovy
+++ b/jobs/build-publish-image.groovy
@@ -42,7 +42,7 @@ def runScript() {
                           params.GIT_REVISION);
 
    // Prune docker images before building if under 1.5GB of disk space.
-   sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
+   sh('[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af')
 
    dir("webapp") {
        if (params.VALIDATE_COMMIT) {

--- a/jobs/update-translation-pipeline.groovy
+++ b/jobs/update-translation-pipeline.groovy
@@ -42,7 +42,7 @@ def runScript() {
                           params.GIT_REVISION);
 
     // Prune docker images before building if under 1.5GB of disk space.
-    sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
+    sh('[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af')
 
     dir("webapp/services/content-editing/translation_pipeline") {
        exec(["make", "push", "ZND_NAME=${params.ZND_NAME}"]);


### PR DESCRIPTION
## Summary:
We're currently running into an error when attempting to build a publish worker image:

```
WorkflowScript: 45: illegal string body character after dollar sign;
   solution: either escape a literal dollar sign "\$5" or bracket the value expression "${5}" @ line 45, column 6.
      sh("[ $(df -BM --output=avail . | tr -cd 0-9) -gt 1500 ] || docker image prune -af")
```

🤞 that switching to single quotes solves the problem.

Full error: https://jenkins.khanacademy.org/job/deploy/job/build-publish-image/219/console

Issue: none

## Test plan:
Re-run the publish worker job.