### PR TITLE
Use runpytests.sh in our jenkins jobs.

### DIFF
--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -49,7 +49,7 @@ def runScript() {
       sh("dev/tools/update_ownership_data.py");
 
       // Check we didn't break anything.
-      sh("tools/runtests.py dev/consistency_tests/ownership_test.py");
+      sh("tools/runpytests.sh dev/consistency_tests/ownership_test.py");
    }
 }
 

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -170,7 +170,7 @@ TESTS = [
     [cmd: "testing/flow_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/typecheck_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/kotlin_test_client.sh -j1 <server>", oneAtATime: true, done: false],
-    [cmd: "testing/runtests.py --quiet --jobs=1 --xml <server>", done: false],
+    [cmd: "testing/runpytests.sh --quiet --jobs=1 --xml <server>", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> javascript", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> python", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> go", oneAtATime: true, done: false],
@@ -499,7 +499,7 @@ def analyzeResults() {
             if (params.MAX_SIZE != "medium") {
                maxSizeParam = " --max-size=${exec.shellEscape(params.MAX_SIZE)}";
             }
-            pythonRerunCommand = "testing/runtests.py${maxSizeParam}"
+            pythonRerunCommand = "testing/runpytests.sh{maxSizeParam}"
             summarize_args = [
                "testing/testresults_util.py", "summarize-to-slack",
                "genfiles/test-reports/", params.SLACK_CHANNEL,

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -499,7 +499,7 @@ def analyzeResults() {
             if (params.MAX_SIZE != "medium") {
                maxSizeParam = " --max-size=${exec.shellEscape(params.MAX_SIZE)}";
             }
-            pythonRerunCommand = "testing/runpytests.sh{maxSizeParam}"
+            pythonRerunCommand = "testing/runpytests.sh${maxSizeParam}"
             summarize_args = [
                "testing/testresults_util.py", "summarize-to-slack",
                "genfiles/test-reports/", params.SLACK_CHANNEL,


### PR DESCRIPTION
## Summary:
We now have runpytests.sh as a wrapper around runtests.py to properly
handle both python2 and python3.  Let's use it!

Issue: https://khanacademy.atlassian.net/browse/INFRA-9106

## Test plan:
groovy jobs/update-ownership-data.groovy
groovy jobs/webapp-test.groovy