### PR TITLE
Backup our graphql safelist as part of our weekly backup.

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -296,6 +296,8 @@ backup_network_config() {
 
 # Delete unused queries from our GraphQL safelist.
 clean_unused_graphql_safelist_queries() {
+    # Let's back it up first.
+    ( cd webapp; tools/datastore-get.sh -prod -format=json GraphQLQuery | gzip | gsutil cp - gs://ka_backups/graphql-safelist/`date +%Y%m%d`.json.gz )
     ( cd webapp; tools/prune_graphql_safelist.sh --prod )
 }
 


### PR DESCRIPTION
## Summary:
It would be very problematic if we accidentally deleted the graphql
safelist datastore models!  Nobody could do anything.  Let's back them
up every week so we can do a manual restore.  (Maybe one day in the
future we'll write a script to do an automated restore.)

Issue: https://khanacademy.atlassian.net/browse/INFRA-6521

## Test plan:
I ran the new command manually on jenkins-server, wich success.