### PR TITLE
[🔥AUDIT🔥] Use the proper test-runner for python tests now.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -170,7 +170,7 @@ TESTS = [
     [cmd: "testing/flow_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/typecheck_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/kotlin_test_client.sh -j1 <server>", oneAtATime: true, done: false],
-    [cmd: "testing/runpytests.sh --quiet --jobs=1 --xml <server>", done: false],
+    [cmd: "testing/py_test_client.sh --quiet --jobs=1 --xml <server>", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> javascript", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> python", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> go", oneAtATime: true, done: false],


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Now that py_test_client.sh is in master, we can call it directly,
rather than having to go through the shim.

Issue: none

## Test plan:
Fingers crossed