### PR TITLE
[🔥AUDIT🔥] Only run `deploy-gateway-config` in the queryplanner directory now.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -535,14 +535,9 @@ def createCloudRunTags(){
 // just do it always.
 def deployToGatewayConfig() {
    dir("webapp") {
-       exec(["make", "-C", "services/graphql-gateway",
-             "deploy-gateway-config",
-             "DEPLOY_VERSION=${NEW_VERSION}"]);
-       if (fileExists("services/queryplanner/Makefile")) {
-          exec(["make", "-C", "services/queryplanner",
-                "deploy-gateway-config",
-                "DEPLOY_VERSION=${NEW_VERSION}"]);
-       }
+      exec(["make", "-C", "services/queryplanner",
+            "deploy-gateway-config",
+            "DEPLOY_VERSION=${NEW_VERSION}"]);
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We moved this rule fraom graphql-gateway/ to queryplanner/ some time
ago.  We tried to run in both directories for builds of commites
before that migration.  But the migration was like over a year ago
now!  I don't think we need to support the old location anymore.

Issue: https://jenkins.khanacademy.org/job/deploy/job/build-webapp/39021/execution/node/198/log/

## Test plan:
groovy jobs/build-webapp.groovy