### PR TITLE
ZNDs:skip deploy-gateway-config on graphql-gateway

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -327,11 +327,9 @@ def deployCronYaml() {
 // just do it always.
 def deployToGatewayConfig() {
    dir("webapp") {
-       if (fileExists("services/queryplanner/Makefile")) {
-          exec(["make", "-C", "services/queryplanner",
-                "deploy-gateway-config",
-                "DEPLOY_VERSION=${VERSION}"]);
-       }
+       exec(["make", "-C", "services/queryplanner",
+             "deploy-gateway-config",
+             "DEPLOY_VERSION=${VERSION}"]);
    }
 }
 

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -327,9 +327,6 @@ def deployCronYaml() {
 // just do it always.
 def deployToGatewayConfig() {
    dir("webapp") {
-       exec(["make", "-C", "services/graphql-gateway",
-             "deploy-gateway-config",
-             "DEPLOY_VERSION=${VERSION}"]);
        if (fileExists("services/queryplanner/Makefile")) {
           exec(["make", "-C", "services/queryplanner",
                 "deploy-gateway-config",


### PR DESCRIPTION
We recently changed this for deploying webapp and need to change it for ZNDs too.

Issue: NA

Test Plan:

Fingers crossed, we can always revert if we need to