### PR TITLE
[🔥AUDIT🔥] Keep a metric ton of delete-versions logs.

### DIFF
--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -12,6 +12,11 @@ import org.khanacademy.Setup;
 
 new Setup(steps
 
+// We run this job once every few minutes; 100 builds covers about
+// 30 minutes.  Let's keep at least a days' around, for debugging.
+).resetNumBuildsToKeep(
+   5000,
+
 ).addStringParam(
     "VERSION",
     """<b>REQUIRED</b>. The names of the versions to delete, separated by


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We run delete-versions continuously -- probably because we have so
many versions at the moment, we could really do a better job of
managing that -- and it's not enough to debug.  Let's keep a lot more
logs so we can debug better.  The logs are short so it should be ok.

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1683676021846129

## Test plan:
None