### PR TITLE
INFRA-9290 Log High level jenkins actions to GOOGL

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -478,6 +478,7 @@ def analyzeResults() {
          // No need to report the results in the case of abort!  They will
          // likely be more confusing than useful.
          echo('We were aborted; no need to report results.');
+         notify.log("Aborted", ["job":"webapp-test"])
          return;
       }
 
@@ -527,11 +528,18 @@ def analyzeResults() {
             env.SENT_TO_SLACK = '1';
          }
       }
+      // TODO(ebrown): Remove: onWorker logs, so not needed here too
+      notify.log("Finished ${env.JOB_NAME} ${env.BUILD_NUMBER}")
    }
 }
 
 
 onWorker(WORKER_TYPE, '5h') {     // timeout
+   // TODO(ebrown): Remove: onWorker logs, so not needed here too
+   notify.log("Starting ${env.JOB_NAME} " + 
+              "${params.REVISION_DESCRIPTION} ${env.BUILD_NUMBER}", [
+   ]);
+
    notify([slack: [channel: params.SLACK_CHANNEL,
                    thread: params.SLACK_THREAD,
                    sender: 'Testing Turtle',

--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -69,6 +69,12 @@ def _makeHttpRequestAndAlert(resource, httpMode, params) {
                httpMode: httpMode,
                requestBody: new JsonBuilder(params).toString(),
                url: "https://buildmaster.khanacademy.org/${resource}");
+            notify.log("Buildmaster request: ${resource}", [
+               resource: resource,
+               response: response,
+               params: params,
+               SEND_SLACK_COUNT: SEND_SLACK_COUNT,
+            ])
             SEND_SLACK_COUNT = 0;
             return response;
          }
@@ -93,6 +99,12 @@ def _makeHttpRequestAndAlert(resource, httpMode, params) {
                [step: "${resource} + ${httpMode}",
                logsUrl: env.BUILD_URL]);
          }
+         notify.log("Buildmaster request failed", [
+            resource: resource,
+            params: params,
+            SEND_SLACK_COUNT: SEND_SLACK_COUNT,
+            level: "ERROR",
+         ])
          return;
       }
    }

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -1,3 +1,7 @@
+import groovy.json.JsonBuilder;
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
 // Normally you will just use notify() directly (via `call()` below).
 // But you may also find it useful to use `notify.fail(msg)`.  This
 // will not only fail the build, it will include `msg` in the slack
@@ -177,6 +181,16 @@ def sendToSlack(slackOptions, status, extraText='') {
    }
 
    _sendToAlertlib(subject, severity, body, extraFlags + channelFlags);
+   log("Sent to slack: ${subject}", [
+         channel: slackOptions.channel,
+         level: severity,
+         subject: subject,
+         sender: sender,
+         body: body,
+         thread: slackOptions.thread,
+         status: status,
+         extra_text: extraText,
+      ]);
    if (_failed(status)) {
       // Also send all failures to dev-support-log
       def logChannelFlags = ["--slack=CB00L3VFZ"];   // dev-support-log
@@ -310,13 +324,147 @@ def sendToBuildmaster(buildmasterOptions, status) {
    try {
       buildmaster.notifyStatus(
          buildmasterOptions.what, buildmasterStatus, buildmasterOptions.sha);
+      log("Notified buildmaster", [
+         level: "INFO",
+         buildmasterStatus: buildmasterStatus,
+         buildmasterOptions: buildmasterOptions,
+         status: status,
+      ])
    } catch (e) {
       echo("Notifying buildmaster failed: ${e.getMessage()}.  Continuing.");
+      log("Notifying buildmaster failed", [
+         level: "ERROR",
+         buildmasterStatus: buildmasterStatus,
+         buildmasterOptions: buildmasterOptions,
+         status: status,
+         exception: e,
+      ]);
+   }
+}
+
+
+// We only support the following severity levels for logging to Google Cloud
+def validLogLevels() {
+   return ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "ALERT", "EMERGENCY"];
+}
+
+
+// Log something to Google Cloud Logging.
+// Supported options in args:
+// level: The severity of the log message.  Possible values are
+//    "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "ALERT", "EMERGENCY".
+//    Defaults to "INFO".
+// log: The name of the log to write to.  Defaults to "jenkins".
+def log(message, args=[:]) {
+   def level = "INFO";
+   def logName = "jenkins";
+   def paramString = ""; // For logging to jenkins
+   try {
+      if (args.level) {
+         level = args.level.toUpperCase();
+         args.remove("level");
+      }
+      if (args.log) {
+         log = args.log;
+         args.remove("log");
+      }
+
+      // Add additional metadata
+      args.buildmaster_deploy_id = params.BUILDMASTER_DEPLOY_ID;
+      args.build_url = env.BUILD_URL;
+      args.build_user = env.BUILD_USER_ID;
+      args.build_number = env.BUILD_NUMBER;
+      args.git_revision = params.GIT_REVISION;
+      args.description = params.REVISION_DESCRIPTION; // branch name
+      args.job_name = env.JOB_NAME;
+      args.virtual_env = env.VIRTUAL_ENV;
+      args.home = env.HOME;
+      args.build_status = env.STATUS;
+
+      // Put it in a format we can echo to a jenkins log
+      paramString = "${args}"
+   } catch (e) {
+      // Ignore -- we'll just use the default.
+   }
+
+  // Not sure what could go wrong here, but be safe!
+   try {
+      if (!(level in validLogLevels())) {
+         echo("Invalid log level: ${level}.  Defaulting to INFO.");
+         level = "INFO";
+      }
+   } catch (e) {
+      // Ignore -- we'll just use the default.
+      level = "INFO"
+   }
+
+   // Log inside jenkins
+   echo("[${level}] ${message} ${paramString}")
+
+   try {
+      args.message = message; // Add message to json for logging to Google Cloud
+      def jsonMessage = new JsonBuilder(args).toPrettyString();
+
+      def shellCommand = ("gcloud logging write " +
+                          "--payload-type=json " +
+                          "--severity=${level} " +
+                          logName + " " +
+                          exec.shellEscape(jsonMessage));
+      sh(shellCommand);
+   } catch (e) {
+      // We never want logging itself to cause a build to fail.
+      echo("Logging to Google Cloud Logging failed: ${e.getMessage()}.  Continuing.");
+   }
+}
+
+
+// Log that we are starting onWorker() or onMaster()
+def logNodeStart(label, timeoutString) {
+   try {
+      env.STATUS = "starting";
+      // The hostname is useful for debugging.
+      hostname = sh(script: "hostname", returnStdout: true).trim();
+      log("start work ${env.JOB_NAME} " + 
+          "${params.REVISION_DESCRIPTION} ${env.BUILD_NUMBER} " +
+          "${timeoutString} ${label} hostname=${hostname}", [
+         hostname: hostname,
+         timeout: timeoutString,
+         label: label,
+      ]);
+   } catch (err) {
+      // We don't want to fail the build if we can't log.
+      echo("node start failed to log: ${err}");
+   }
+}
+
+
+// Log that we are finishing onWorker() or onMaster()
+def logNodeFinish(label, timeoutString, start) {
+   try {
+      if (env.STATUS == "starting") {
+         env.STATUS = "finishing";
+      }
+      // The hostname is useful for debugging.
+      hostname = sh(script: "hostname", returnStdout: true).trim();
+      duration = (new Date().getTime() - start.getTime()) / 1000;
+      log("finishing work ${env.JOB_NAME} " + 
+          "${params.REVISION_DESCRIPTION} ${env.BUILD_NUMBER} " +
+          "hostname=${hostname}", [
+         hostname: hostname,
+         timeout: timeoutString,
+         label: label,
+         start: start,
+         seconds: duration,
+      ]);
+   } catch (err) {
+      // We don't want to fail the build if we can't log.
+      echo("node finish failed to log: ${err}");
    }
 }
 
 
 def fail(def msg, def statusToSet="FAILURE") {
+   env.STATUS = statusToSet + ":" + msg;
    throw new FailedBuild(msg, statusToSet);
 }
 

--- a/vars/onMaster.groovy
+++ b/vars/onMaster.groovy
@@ -5,6 +5,8 @@
 
 def call(timeoutString, Closure body) {
    node("master") {
+      start = new Date();
+      notify.logNodeStart("master", timeoutString);
       timestamps {
          kaGit.checkoutJenkinsTools();
          withVirtualenv() {
@@ -25,5 +27,6 @@ def call(timeoutString, Closure body) {
             }
          }
       }
+      notify.logNodeFinish("master", timeoutString, start);
    }
 }

--- a/vars/onWorker.groovy
+++ b/vars/onWorker.groovy
@@ -36,6 +36,8 @@ def call(def label, def timeoutString, Closure body) {
    }
 
    node(label) {
+      start = new Date();
+      notify.logNodeStart(label, timeoutString);
       timestamps {
          // We use a shared workspace for all jobs that are run on the
          // worker machines.
@@ -69,6 +71,7 @@ def call(def label, def timeoutString, Closure body) {
                      body();
                   }
                }
+               notify.logNodeFinish(label, timeoutString, start);
             }
          }
       }


### PR DESCRIPTION
This code logs the start and completion of all onWorker and onMaster steps to the google logging service.  This is useful for debugging and auditing.

All code is meant to be very defensive such that if the logging fails, the build will continue. There is risk that defensive coding was overlooked somewhere and the Khan Academy build system could be impacted. A quick revert is recommended if destabilization is noticed.

It is NOT meant to be efficient. This can likely be fixed with more effort, but the initial goal is to get better telemetry for other efforts. The downside is that this logging should not be used liberally or it could impact performance and cost.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9290

Test Plan:

I've been testing this code using the jenkins replay feature for one webapp-test job. I've also created intentional exceptions to improve my confidence in the defensive coding.

My recommendation is to deploy this code and then watch all active jobs for 60 minutes watching for exceptions (in jenkins logs). If that goes well, keeping an eye on this for the next few days would be good.