### PR TITLE
[🔥AUDIT🔥] Remove command to run flow_test_client.sh

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -167,7 +167,6 @@ WORKER_TYPE = (params.MAX_SIZE in ["large", "huge"]
 //    that is modified.  It's used only as a small perf optimization;
 //    things still work even if `done` is never set to true.
 TESTS = [
-    [cmd: "testing/flow_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/typecheck_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/mypy_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/kotlin_test_client.sh -j1 <server>", oneAtATime: true, done: false],


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I got rid of flow_test_client.sh in https://github.com/Khan/webapp/pull/15380 since we're no longer using Flow anywhere.

Issue: None

## Test plan:
- land and deploy ts-static which migrates the static service to TypeScript