### PR TITLE
[🔥AUDIT🔥] Fix the flags passed to runtests.sh.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -170,15 +170,15 @@ TESTS = [
     [cmd: "testing/flow_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/typecheck_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/mypy_test_client.sh -j1 <server>", done: false],
-    [cmd: "tools/runtests.sh -j1 --server=<server>/tests/kotlin", oneAtATime: true, done: false],
-    [cmd: "tools/runtests.sh -j1 --server=<server>/tests/python", done: false],
+    [cmd: "tools/runtests.sh -j 1 --server=<server>/tests/kotlin", oneAtATime: true, done: false],
+    [cmd: "tools/runtests.sh -j 1 --server=<server>/tests/python", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> javascript", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> python", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> go", oneAtATime: true, done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> kotlin", done: false],
     [cmd: "testing/lint_test_client.sh -j1 <server> other", done: false],
-    [cmd: "tools/runtests.sh -j1 --server=<server>/tests/javascript", done: false],
-    [cmd: "tools/runtests.sh -j1 --server=<server>/tests/go", done: false],
+    [cmd: "tools/runtests.sh -j 1 --server=<server>/tests/javascript", done: false],
+    [cmd: "tools/runtests.sh -j 1 --server=<server>/tests/go", done: false],
 ];
 
 // Gloabally scoped to allow the test runner to set this and allow us to skip analysis as well


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Go does not support flags like `-j1`.  It needs to be `-j 1`.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1690449539319869

## Test plan:
Fingers crossed, will try running make-allcheck again