### PR TITLE
Change the e2e job to get its secrets from gsm instead of keeper.

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -165,12 +165,12 @@ def _setupWebapp() {
 def runLambdaTest() {
    // We need login creds for LambdaTest Cli
    def lt_username = sh(script: """\
-      keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
-      get qvYpo_KnpCiLBN69fYpEYA --format json | jq -r .login\
+      gcloud --project khan-academy secrets describe \
+      lambdatest_admin_account --format json | jq -r .annotations.login \
       """, returnStdout:true).trim();
    def lt_access_key = sh(script: """\
-      keeper --config ${exec.shellEscape("${HOME}/.keeper-config.json")} \
-      get qvYpo_KnpCiLBN69fYpEYA --format json | jq -r .password\
+      gcloud --project khan-academy secrets versions access latest \
+      --secret lambdatest_admin_account \
       """, returnStdout:true).trim();
 
    // Determine which environment we're running against, so we can provide a tag


### PR DESCRIPTION
## Summary:
We're moving from keeper to google secrets manager.  We've already
transitioned over all the secrets, and given jenkins access to all the
ones it needs.  This changes the script to make use of that.

`git grep keeper` shows no other jobs need to be changed.

I also ran:
```
gcloud --project khan-academy secrets get-iam-policy lambdatest_admin_account
```
and ensured that group:secrets-prod-ro@khanacademy.org has the
secretAccessor role, so Jenkins can read this secret.

Issue: INFRA-XXXX

## Test plan:
Fingers crossed