### PR TITLE
Clean up all old ka-content buckets.

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -177,8 +177,6 @@ clean_ka_translations() {
 clean_ka_content_data() {
     for dir in `gsutil ls gs://ka-content-data gs://ka-revision-data | grep -v :$`; do
         ka_locale=`echo "$dir" | cut -d/ -f4`
-        # TODO(csilvers): enable on all locales once we're comfortable with.
-        [ "$ka_locale" = "lol" ] || continue
 
         # This sorts by date.  Each line looks like:
         #  <size>  YYYY-MM-DDTHH:MM:SSZ  gs://ka-*-data/<ka-locale>/[snapshot|manifest]-<hash>.json


### PR DESCRIPTION
## Summary:
To support a gradual rollout, in #114 I made it so we only clean the
lol ka-content bucket.  That seems to have been going well, so now I
extend it to all bucket!

Issue: https://khanacademy.slack.com/archives/C49296Q7P/p1686584563057689

## Test plan:
See above