### PR TITLE
[🔥AUDIT🔥] Replace runpytests.sh with runtests.sh.

### DIFF
--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -49,7 +49,7 @@ def runScript() {
       sh("dev/tools/update_ownership_data.py");
 
       // Check we didn't break anything.
-      sh("testing/runpytests.sh dev/consistency_tests/ownership_test.py");
+      sh("testing/runtests.sh dev/consistency_tests/ownership_test.py");
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
runpytests doesn't exist anymore.  We can just use the main runtests
runner.

Issue: https://khanacademy.slack.com/archives/C3UDL9QN7/p1694167714011689

## Test plan:
Fingers crossed, will run this job manually