### PR TITLE
[🔥AUDIT🔥] Tell people to run runtests.sh, not runpytests.py.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -494,14 +494,7 @@ def analyzeResults() {
 
       withSecrets() {     // we need secrets to talk to slack!
          dir("webapp") {
-            // We try to keep the command short and clear.
-            // max-size is the only option we need locally, and only
-            // if it is not "medium".
-            maxSizeParam = "";
-            if (params.MAX_SIZE != "medium") {
-               maxSizeParam = " --max-size=${exec.shellEscape(params.MAX_SIZE)}";
-            }
-            pythonRerunCommand = "testing/runpytests.sh${maxSizeParam}"
+            pythonRerunCommand = "tools/runtests.sh";
             summarize_args = [
                "testing/testresults_util.py", "summarize-to-slack",
                "genfiles/test-reports/", params.SLACK_CHANNEL,


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The latter is gone now, replaced by the former.  The test-size flag
has also gone away (we don't have any "huge" tests left anymore, so
it's become a non-issue).

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1694542433441139

## Test plan:
groovy jobs/webapp-test.groovy