### PR TITLE
[🔥AUDIT🔥] Ignore updated generated files when creasting devserver images.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -59,6 +59,10 @@ def runScript() {
 def publishResults() {
    dir("webapp") {
       sh("git add dev/server/.env.latest_uploaded_build_tag");
+      // The upload-all-static-images rule can modify some other generated
+      // files, that we don't care about.  `git restore .` resets everything
+      // in the client except files that have been `git add`-ed.
+      sh("git restore .");
    }
    // Check it in!
    kaGit.safeCommitAndPush(


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The upload-all-static-images rule can modify some other generated
files, that we don't care about.  We reset everything in the client
except for the one file we explicitly care about.

Issue: https://khanacademy.slack.com/archives/C3UDL9QN7/p1694558657116679

## Test plan:
Fingers crossed