### PR TITLE
Make the paths set in onWorker and onMaster match .profile.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -47,11 +47,8 @@ def runScript() {
 
       sh("make fix_deps");  // force a remake of all deps all the time
 
-      // Run the script!  We need to add ~/go/bin to the path because
-      // that's where `ko` lives.
-      withEnv(["PATH=${env.PATH}:${env.HOME}/go/bin"]) {
-         sh("make -C dev/server upload-all-static-images");
-      }
+      // Run the script!
+      sh("make -C dev/server upload-all-static-images");
    }
 }
 

--- a/vars/onMaster.groovy
+++ b/vars/onMaster.groovy
@@ -18,9 +18,12 @@ def call(timeoutString, Closure body) {
                 // To export BOTO_CONFIG, for some reason, worker did not
                 // source the .profile or .bashrc anymore.
                 withEnv(["BOTO_CONFIG=${env.HOME}/.boto",
-                         "PATH=/usr/local/google_appengine:" +
+                         "PATH=" +
+                         "/home/ubuntu/webapp-workspace/devtools/khan-linter/bin:" +
+                         "/var/lib/jenkins/repositories/khan-linter/bin" +
+                         "/usr/local/google_appengine:" +
                          "/home/ubuntu/google-cloud-sdk/bin:" +
-                         "${env.HOME}/git-bigfile/bin:" +
+                         "${env.HOME}/go/bin:" +
                          "${env.PATH}"]) {
                      body();
                 }

--- a/vars/onWorker.groovy
+++ b/vars/onWorker.groovy
@@ -62,10 +62,12 @@ def call(def label, def timeoutString, Closure body) {
                // To export BOTO_CONFIG, for some reason, worker did not
                // source the .profile or .bashrc anymore.
                withEnv(["BOTO_CONFIG=/home/ubuntu/.boto",
-                        "PATH=/usr/local/google_appengine:" +
+                        "PATH=" +
+                        "/home/ubuntu/webapp-workspace/devtools/khan-linter/bin:" +
+                        "/var/lib/jenkins/repositories/khan-linter/bin" +
+                        "/usr/local/google_appengine:" +
                         "/home/ubuntu/google-cloud-sdk/bin:" +
-                        "/usr/local/bin/:" +
-                        "${env.HOME}/git-bigfile/bin:" +
+                        "${env.HOME}/go/bin:" +
                         "${env.PATH}"]) {
                   withVirtualenv() {
                      body();


### PR DESCRIPTION
## Summary:
Sadly, jenkins doesn't exec `.profile` or `.bashrc` when running
jenkins jobs, it just uses the same path the jenkins binary uses.

On the workers, the jenkins binary (actually the `jar slave.jar`
process) runs via ssh, which *does* exec `.profile`, so all jenkins
jobs on workers run with the path that's in `.profile`.

But on the main jenkins server, the jenkins binary (`jar jenkins.jar`)
runs via systemd, which uses its own default path.  In particular,
systemd runs as root (and later does a proces-chown to the jenkins
user), so it does not use jenkins's .profile.

There might be some way to change this in systemd, but that's pretty
black magic.  Instead, we just set the path we want in our
onWorker.groovy and onMaster.groovy scripts, which run at the
"outside" of all our jenkins jobs.

Unfortunately, the paths set in those scripts had gotten out of date
with the path set in the .profile file.  I get them back in sync, and
add a breadcrumb in .profile so hopefully if the path changes again,
we'll update it everywhere we need to.

This lets me remove the explicit path-adding in
update-devserver-static-images.groovy, which was always an awkward
hack.

Issue: none

## Test plan:
Fingers crossed.  In theory this shouldn't affect any jobs, but we'll
have to land it and see..