### PR TITLE
Format services lists

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -41,6 +41,12 @@ import org.khanacademy.Setup;
 //import vars.withTimeout
 
 
+def formatServicesList(services) {
+   return services
+      .collect({ svc -> "`${svc}`" })
+      .join(", ");
+}
+
 new Setup(steps
 
 // We only need to lock out for promoting; builds are fine to do in parallel.
@@ -647,7 +653,7 @@ def deployAndReport() {
       _alert(alertMsgs.JUST_DEPLOYED,
              [deployUrl: DEPLOY_URL,
               version: NEW_VERSION,
-              services: SERVICES.join(', '),
+              services: formatServicesList(SERVICES),
               branches: REVISION_DESCRIPTION,
               logsUrl: ("https://console.cloud.google.com/logs/viewer?" +
                         "project=khan-academy&resource=gae_app%2F" +
@@ -683,7 +689,7 @@ def finishWithFailure(why) {
       _alert(alertMsgs.FAILED_WITHOUT_ROLLBACK,
              [version: NEW_VERSION,
               // TODO(benkraft): Report specifically which service failed.
-              services: SERVICES.join(', ') ?: "tools-only",
+              services: formatServicesList(SERVICES) ?: "tools-only",
               branch: REVISION_DESCRIPTION,
               why: why]);
       env.SENT_TO_SLACK = '1';


### PR DESCRIPTION
## Summary:

While preparing the post mortem for #incident-20230911 I noticed that messages originating from our Jenkins jobs don't format the services list as nice as Sun III does. 

Here's how Sun formats them:

<img width="399" alt="image" src="https://github.com/Khan/jenkins-jobs/assets/77138/0735d0b3-72c4-427c-9701-0c7a811fadc4">

And Mr. Monkey before this PR:

| [Mr. Monkey Deploy Failure](https://khanacademy.slack.com/archives/C096UP7D0/p1694558999515299?thread_ts=1694557986.518789&cid=C096UP7D0) | [Mr. Monkey Just Uploaded](https://khanacademy.slack.com/archives/C096UP7D0/p1694559610890579?thread_ts=1694557986.518789&cid=C096UP7D0)  |
| ------------------------- | ------------------------- |
| <img width="382" alt="image" src="https://github.com/Khan/jenkins-jobs/assets/77138/88411f38-8ad2-4c37-9449-b39b81da7c9d"> | <img width="391" alt="image" src="https://github.com/Khan/jenkins-jobs/assets/77138/57e86ffc-8415-4284-8127-265ca83f21c7"> |
 
Issue: "none"

## Test plan:

Do we have any tests for this code? Happy to write some if we have a test strategy in place. 

I did test the `.collect().join()` construct here: https://onecompiler.com/groovy/3zmjynhkw