### PR TITLE
FEI-5292: Don't run flow_test_client.sh

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -167,7 +167,6 @@ WORKER_TYPE = (params.MAX_SIZE in ["large", "huge"]
 //    that is modified.  It's used only as a small perf optimization;
 //    things still work even if `done` is never set to true.
 TESTS = [
-    [cmd: "testing/flow_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/typecheck_test_client.sh -j1 <server>", done: false],
     [cmd: "testing/mypy_test_client.sh -j1 <server>", done: false],
     [cmd: "tools/runtests.sh -j 1 --server=<server>/tests/kotlin", oneAtATime: true, done: false],


### PR DESCRIPTION
## Summary:
We don't use Flow for any of our code in webapp anymore.  This is evidenced by the fact that there are no longer any .flowconfig files in that repo.

NOTE: This should be merged before deploying https://github.com/Khan/webapp/pull/16759.

Issue: FEI-5292

## Test plan:
- n/a