### PR TITLE
Keep around more of our deploy logs, for longer.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -46,6 +46,11 @@ new Setup(steps
 // We only need to lock out for promoting; builds are fine to do in parallel.
 ).allowConcurrentBuilds(
 
+// Sometimes we want to debug a deploy a week or two later.  Let's
+// keep a lot of these.
+).resetNumBuildsToKeep(
+   500,
+
 ).addStringParam(
     "GIT_REVISION",
     """<b>REQUIRED</b>. The sha1 to deploy.""",

--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -15,7 +15,7 @@ new Setup(steps
 // We run this job once every few minutes; 100 builds covers about
 // 30 minutes.  Let's keep at least a days' around, for debugging.
 ).resetNumBuildsToKeep(
-   5000,
+   9000,
 
 ).addStringParam(
     "VERSION",

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -56,6 +56,11 @@ import org.khanacademy.Setup;
 // the buildmaster, but we do it too as an extra safety check.
 new Setup(steps
 
+// Sometimes we want to debug a deploy a week or two later.  Let's
+// keep a lot of these.
+).resetNumBuildsToKeep(
+   500,
+
 ).addStringParam(
     "GIT_REVISION",
     """<b>REQUIRED</b>. The sha1 to deploy.""",

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -18,7 +18,7 @@ new Setup(steps
 // We do a lot of e2e-test runs, and QA would like to be able to see details
 // for a bit longer.
 ).resetNumBuildsToKeep(
-   250,
+   350,
 
 ).addStringParam(
    "URL",

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -30,7 +30,7 @@ new Setup(steps
 // We do a *ton* of webapp-test runs, often >100 each day.  Make sure we don't
 // clean them too quickly.
 ).resetNumBuildsToKeep(
-   500,
+   1500,
 
 ).addStringParam(
    "GIT_REVISION",


### PR DESCRIPTION
## Summary:
We reap old logs periodically so the jenkins-server disk doesn't fill
up.  But we've been finding sometimes we wish some logs stayed around
a bit longer, for debugging.  This PR makes us save more, to help with
that.

Our jenkins-server has a huge amount of disk space free at the moment
-- something like half a petabyte -- so I'm not worried about logs
filling it up.

Issue: https://khanacademy.slack.com/archives/D9SJ6VASC/p1695073769786779

## Test plan:
groovy jobs/*.groovy