### PR TITLE
[🔥AUDIT🔥] Logging for failed http requests to buildmaster

### DIFF
--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -83,6 +83,7 @@ def _makeHttpRequestAndAlert(resource, httpMode, params) {
          // it's not being caught properly.
          // httpRequest throws exceptions when buildmaster responds with status
          // code >=400
+         echo("Error talking to buildmaster [${resource}]: ${e}");
 
          // checkout jenkins-jobs folder in current workspace
          // in order to load other groovy file.
@@ -104,6 +105,7 @@ def _makeHttpRequestAndAlert(resource, httpMode, params) {
             params: params,
             SEND_SLACK_COUNT: SEND_SLACK_COUNT,
             level: "ERROR",
+            error: e.getMessage(),
          ])
          return;
       }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We are having issues aborting jobs and I have traced it back to a race condition between the http request we send to buildmaster for `prompt-status` for `set-default` and when the message for aborting a job is processed by jenkins.  Its unclear to me what error it is we are getting when the request fails so I am adding logging for it.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9495

## Test plan:
groovy vars/*.groovy