### PR TITLE
Reduce how much we depend on secrets.py in jenkins-jobs.

### DIFF
--- a/jobs/deploy-fastly.groovy
+++ b/jobs/deploy-fastly.groovy
@@ -24,6 +24,7 @@ import org.khanacademy.Setup;
 //import vars.clean
 //import vars.kaGit
 //import vars.notify
+//import vars.withSecrets
 //import vars.withTimeout
 
 
@@ -123,7 +124,7 @@ def deploy() {
 
 def setDefault() {
    withTimeout('5m') {
-      withSecrets() { // to report the change to #whats-happening
+      withSecrets.slackAlertlibOnly() { // to report to #whats-happening
          dir("webapp/services/fastly-khanacademy") {
             sh(params.TARGET == "prod" ? "make set-default" : "make set-default-test");
          }
@@ -142,7 +143,7 @@ def notifyWithVersionInfo(oldActive, newActive) {
        "--severity=info",
        "--summary=${subject}",
    ];
-   withSecrets() {     // to talk to slack
+   withSecrets.slackAlertlibOnly() {
       sh("echo ${exec.shellEscape(body)} | ${exec.shellEscapeList(cmd)}");
    }
 }

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -9,7 +9,6 @@ import org.khanacademy.Setup;
 //import vars.exec
 //import vars.notify
 //import vars.withTimeout
-//import vars.withSecrets
 
 new Setup(steps
 

--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -17,8 +17,8 @@ import org.khanacademy.Setup;
 //import vars.exec
 //import vars.kaGit
 //import vars.notify
-//import vars.withTimeout
 //import vars.withSecrets
+//import vars.withTimeout
 
 // We try to keep minimal options in this job: you don't want to have to
 // figure out which options are right when the site is down!
@@ -75,7 +75,7 @@ def _alert(def msg) {
            "--icon-emoji=:monkey_face:",
            "--slack-simple-message",
           ];
-   withSecrets() {     // to talk to slack
+   withSecrets.slackAlertlibOnly() {
       sh("echo ${exec.shellEscape(msg)} | ${exec.shellEscapeList(args)}");
    }
 }
@@ -129,7 +129,7 @@ def verifyValidTag(tag) {
 
 def doRollback() {
    withTimeout('30m') {
-      withSecrets() {
+      withSecrets.slackAlertlibOnly() {  // rollback.py talks to slack
          cmd = ["deploy/rollback.py"];
          if (params.DRY_RUN) {
             cmd += ["-n"];

--- a/jobs/find-failing-taskqueue-tasks.groovy
+++ b/jobs/find-failing-taskqueue-tasks.groovy
@@ -6,6 +6,7 @@ import org.khanacademy.Setup;
 //import vars.exec
 //import vars.kaGit
 //import vars.notify
+//import vars.withSecrets
 
 
 new Setup(steps
@@ -29,7 +30,7 @@ onMaster('1h') {
       stage("Running script") {
          kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", "master");
          sh("make -C webapp python_deps")
-         withSecrets() {  // to talk to slack
+         withSecrets.slackAlertlibOnly() {  // because we pass --slack-channel
             dir("webapp") {
                exec(["dev/tools/failing_taskqueue_tasks.py",
                      "--slack-channel=${params.SLACK_CHANNEL}"]);

--- a/jobs/firstinqueue-priming.groovy
+++ b/jobs/firstinqueue-priming.groovy
@@ -30,7 +30,6 @@ import org.khanacademy.Setup;
 //import vars.notify
 //import vars.withTimeout
 //import vars.onWorker
-//import vars.withSecrets
 
 
 new Setup(steps

--- a/jobs/notify-znd-owners.groovy
+++ b/jobs/notify-znd-owners.groovy
@@ -16,8 +16,8 @@ import org.khanacademy.Setup;
 // Vars we use, under jenkins-jobs/vars/.  This is just for documentation.
 //import vars.kaGit
 //import vars.notify
-//import vars.withTimeout
 //import vars.withSecrets
+//import vars.withTimeout
 
 
 // The simplest setup ever! -- we only want the defaults.
@@ -27,7 +27,7 @@ new Setup(steps).apply();
 def runScript() {
    withTimeout('1h') {
       kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", "master");
-      withSecrets() {      // we need secrets to talk to slack
+      withSecrets.slackAlertlibOnly() {  // because we pass --notify_slack
          dir("webapp") {
             sh("make clean_pyc");    // in case some .py files went away
             sh("make python_deps");

--- a/jobs/qa-metrics.groovy
+++ b/jobs/qa-metrics.groovy
@@ -8,7 +8,6 @@ import org.khanacademy.Setup;
 //import vars.exec
 //import vars.notify
 //import vars.withTimeout
-//import vars.withSecrets
 
 
 new Setup(steps

--- a/jobs/update-i18n-lite-videos.groovy
+++ b/jobs/update-i18n-lite-videos.groovy
@@ -10,7 +10,6 @@ import org.khanacademy.Setup;
 //import vars.kaGit
 //import vars.notify
 //import vars.withTimeout
-//import vars.withSecrets
 
 
 new Setup(steps
@@ -33,19 +32,17 @@ def updateRepo() {
 
 def runAndUpload() {
    withTimeout('22h') {
-      withSecrets() {
-         dir("webapp") {
-            sh("mkdir -p ../lite-video-data");
-            // Download the current videos from gcs so we can update them.
-            exec(["gsutil", "-m", "rsync",
-                  "gs://ka-lite-homepage-data/", "../lite-video-data/"]);
+      dir("webapp") {
+         sh("mkdir -p ../lite-video-data");
+         // Download the current videos from gcs so we can update them.
+         exec(["gsutil", "-m", "rsync",
+               "gs://ka-lite-homepage-data/", "../lite-video-data/"]);
 
-            exec(["tools/content/update-i18n-lite-videos.sh", "../lite-video-data"]);
+         exec(["tools/content/update-i18n-lite-videos.sh", "../lite-video-data"]);
 
-            // Now upload the changes
-            exec(["gsutil", "-m", "rsync",
-                  "../lite-video-data/", "gs://ka-lite-homepage-data/"]);
-         }
+         // Now upload the changes
+         exec(["gsutil", "-m", "rsync",
+               "../lite-video-data/", "gs://ka-lite-homepage-data/"]);
       }
    }
 }

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -491,7 +491,7 @@ def analyzeResults() {
       // The test-server wrote junit files to this dir as it ran.
       junit("webapp/genfiles/test-reports/*.xml");
 
-      withSecrets() {     // we need secrets to talk to slack!
+      withSecrets.slackAlertlibOnly() {
          dir("webapp") {
             pythonRerunCommand = "tools/runtests.sh";
             summarize_args = [

--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -5,6 +5,7 @@ import groovy.transform.Field;
 // Vars we use, under jenkins-jobs/vars/.  This is just for documentation.
 //import vars.notify
 //import vars.retry
+//import vars.withSecrets
 
 
 @Field BUILDMASTER_TOKEN = null;
@@ -37,8 +38,7 @@ def _sendSimpleInterpolatedMessage(def rawMsg, def interpolationArgs) {
                "--icon-emoji=${EMOJI}",
                "--slack-simple-message"];
 
-   // Secrets required to talk to slack.
-   withSecrets() {
+   withSecrets.slackAlertlibOnly() {
       sh("echo ${exec.shellEscape(msg)} | ${exec.shellEscapeList(args)}");
    }
 }

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -158,8 +158,8 @@ def safeUpdateSubmodulePointerToMaster(repoDir, submoduleDir) {
 // Submodules is as in _submodulesArg`.
 def safeMergeFromBranch(dir, commitToMergeInto, branchToMerge, submodules=[]) {
    // This job talks directly to slack on error (for better or worse),
-   // so it needs secrets.
-   withSecrets() {
+   // so it needs that secret.
+   withSecrets.slackAlertlibOnly() {
       exec(["jenkins-jobs/safe_git.sh", "merge_from_branch",
             dir, commitToMergeInto, branchToMerge]
            + _submodulesArg(submodules));
@@ -170,8 +170,8 @@ def safeMergeFromBranch(dir, commitToMergeInto, branchToMerge, submodules=[]) {
 // Submodules is as in _submodulesArg`.
 def safeMergeFromMaster(dir, commitToMergeInto, submodules=[]) {
    // This job talks directly to slack on error (for better or worse),
-   // so it needs secrets.
-   withSecrets() {
+   // so it needs that secret.
+   withSecrets.slackAlertlibOnly() {
       exec(["jenkins-jobs/safe_git.sh", "merge_from_master",
             dir, commitToMergeInto] + _submodulesArg(submodules));
    }

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -236,6 +236,7 @@ def sendToGithub(githubOptions, status, extraText='') {
       flags += ["--github-owner=${githubOptions.owner}"];
    }
 
+   // TODO(csilvers): make a withSecrets() call here (for github secrets)
    _sendToAlertlib(subject, severity, body, flags);
 }
 

--- a/vars/withSecrets.groovy
+++ b/vars/withSecrets.groovy
@@ -50,7 +50,10 @@ def call(Closure body) {
 def slackAlertlibOnly(Closure body) {
    // TODO(csilvers): provide another implementation that just gets the
    // one slack secret from GCS.  But properly promote from this to a
-   // "real" withSecrets call later.
+   // "real" withSecrets call later.  One idea: put these secrets in
+   // workspace root, and set ALERTLIB_SECRETS_DIR to that, and then
+   // have withSecrets override that ALBERTLIB_SECRETS_DIR, but for us
+   // if ALERTLIB_SECRETS_DIR is set it's a noop.
    _withSecrets(body);
 }
 

--- a/vars/withSecrets.groovy
+++ b/vars/withSecrets.groovy
@@ -13,9 +13,7 @@ def _secretsPasswordPath() {
    return "${env.HOME}/secrets_py/secrets.py.aes.password";
 }
 
-
-// This must be called from workspace-root.
-def call(Closure body) {
+def _withSecrets(Closure body) {
    try {
       // First, set up secrets.
       // This decryption command was modified from the make target
@@ -30,7 +28,7 @@ def call(Closure body) {
       _activeSecretsBlocks++;
 
       // Then, tell alertlib where secrets live, and run the wrapped block.
-      withEnv(["ALERTLIB_SECRETS_DIR=${pwd()}/webapp/shared"]){
+      withEnv(["ALERTLIB_SECRETS_DIR=${pwd()}/webapp/shared"]) {
          body();
       }
    } finally {
@@ -43,6 +41,18 @@ def call(Closure body) {
    }
 }
 
+
+// This must be called from workspace-root.
+def call(Closure body) {
+   _withSecrets(body);
+}
+
+def slackAlertlibOnly(Closure body) {
+   // TODO(csilvers): provide another implementation that just gets the
+   // one slack secret from GCS.  But properly promote from this to a
+   // "real" withSecrets call later.
+   _withSecrets(body);
+}
 
 // Only try to decrypt secrets if webapp is checked out
 // and secrets are present.

--- a/vars/withSecrets.txt
+++ b/vars/withSecrets.txt
@@ -4,3 +4,7 @@ It must be called while the current directory is the workspace-root.
 
 NOTE(benkraft): withSecrets is leaky; other branches of the same job will see
 the secrets file too, even if they are not in a withSecrets block.
+
+We also provide the ability to just decrypt one secret: the slack
+secret that alertlib needs to talk to slack.  It is a surprisingly
+common case that that is the only secret we need for a given use.


### PR DESCRIPTION
## Summary:
We're working to get rid of secrets.py (at least once the SAT product
goes away, and we no longer have any python2 in prod).  One large
remaining client is jenkins, which uses `withSecrets()` in a lot of
places.  This PR works to normalize those uses.

It does this in 2 ways:

1. Some uses are unnecessary: they either call python code that
   doesn't require secrets, or they don't even call python code at all
   anymore.  I just removed those withSecerts calls.

2. Some uses are just for slack: they either call a python script that
   only uses secrets to talk to slack, or they call alertlib directly,
   to talk to slack.  In those cases, I use a new
   withSecrets.forSlackAlertlib only.  Right now that is just an alias
   for `withSecrets`, but in a follow-up PR I'll make it fetch just
   the one secret (and directly from GSM, not from secrets.py).

We're left with withSecrets being used in only two places.  The first,
when deploying the SAT product, is unavoidable but will go away once
we no longer deploy python2.  The second is for a few secripts that
are obsolete but still in source control.  We should delete the
scripts, but not in this PR.

Issue: none

## Test plan:
Fingers crossed: I'll try doing a deploy with this on a friday.