### PR TITLE
Add a `when` to the github notification type.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -539,7 +539,8 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
                    emoji: ':turtle:',
                    when: ['FAILURE', 'UNSTABLE']],
            github: [sha: params.GIT_REVISION,
-                    context: 'webapp-test'],
+                    context: 'webapp-test',
+                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']],
            buildmaster: [sha: params.GIT_REVISION,
                          what: 'webapp-test']]) {
       initializeGlobals();

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -566,7 +566,7 @@ def call(options, Closure body) {
             sendToSlack(options.slack, status, failureText);
          }
       }
-      if (options.github) {
+      if (options.github && _shouldReport(status, options.github.when) {
          sendToGithub(options.github, status, failureText);
       }
       if (options.email && _shouldReport(status, options.email.when)) {


### PR DESCRIPTION
## Summary:
This makes it consistent with all the other types.  Since we want to
always send to github, the `when` is all possible states.  (Though
maybe we don't want it for aborted?)

Issue: https://khanacademy.slack.com/archives/C013ANU53LK/p1697576502336959

## Test plan:
Will test on jenkins