### PR TITLE
Provide the ability to only load only a few secrets for calling alertlib.

### DIFF
--- a/jobs/make-allcheck.groovy
+++ b/jobs/make-allcheck.groovy
@@ -66,12 +66,11 @@ onMaster('5h') {
    notify([slack: [channel: '#1s-and-0s', when: ['STARTED', 'ABORTED']]]) {
       // We need this only to get the secrets to send to slack/asana/etc
       // when there are failures.
-      // TODO(csilvers): move those secrets somewhere else instead.
-      kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", "master", null);
 
       parallel([
          "webapp-test": { runAllTests(); },
          "smoke-tests": { runSmokeTests(); },
       ])
+
    }
 }


### PR DESCRIPTION
## Summary:
Now, when you send to slack or github using alertlib, we only load the
one slack secret (or github secret) needed for this.  And we load it
directly from GSM, rather than depending on secrets.py.

As a happy side-effect, this means we can now use use alertlib without
needing webapp cloned.  I take advantage of that by no longer cloning
webapp in the make-allcheck job, which we used to do just to get
secrets for sending alerts to slack.

Issue: none

## Test plan:
Will try running on jenkins!