### PR TITLE
Get rid of send-to-email support, which hasn't worked in a long time.

### DIFF
--- a/jobs/update-i18n-lite-videos.groovy
+++ b/jobs/update-i18n-lite-videos.groovy
@@ -56,9 +56,7 @@ onMaster('23h') {
                    sender: 'I18N Imp',
                    emoji: ':smiling_imp:', emojiOnFailure: ':imp:',
                    extraText: "@cp-support",
-                   when: ['FAILURE', 'UNSTABLE', 'ABORTED']],
-           email: [to: 'jenkins-admin+builds',
-                   when: ['BACK TO NORMAL', 'FAILURE', 'UNSTABLE']]]) {
+                   when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Updating webapp repo") {
          updateRepo();
       }

--- a/jobs/webapp-maintenance.groovy
+++ b/jobs/webapp-maintenance.groovy
@@ -50,9 +50,7 @@ onMaster('10h') {
    notify([slack: [channel: '#infrastructure',
                    sender: 'Mr Monkey',
                    emoji: ':monkey_face:',
-                   when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']],
-           email: [to: 'jenkins-admin+builds, csilvers',
-                   when: ['BACK TO NORMAL', 'FAILURE', 'UNSTABLE']]]) {
+                   when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       def jobs = [];
       stage("Listing jobs to run") {
          def job_str = exec.outputOf(["jenkins-jobs/weekly-maintenance.sh", "-l"]);

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -241,31 +241,6 @@ def sendToGithub(githubOptions, status, extraText='') {
 
 
 // Supported options:
-// when (required): under what circumstances to send to email; a list.
-//    Possible values are SUCCESS, FAILURE, UNSTABLE, or BACK TO NORMAL.
-//    (Used in call(), below.)
-// to (required): a string saying who to send mail to.  We automatically
-//    append "@khanacademy.org" to each email address in the list.
-//    If you want to send to multiple people, use a comma: "sal, team".
-// cc: a string saying who to cc on the email.  Format is the same as
-//    for `to`.
-// [extraText: if specified, text to add to the email body.]
-def sendToEmail(emailOptions, status, extraText='') {
-   def arr = _dataForAlertlib(status, extraText);
-   def subject = arr[0];
-   def severity = arr[1];
-   def body = arr[2];
-   subject += "${currentBuild.displayName}";
-
-   def extraFlags = ["--mail=${emailOptions.to}",
-                     "--cc=${emailOptions.cc ?: ''}",
-                     "--sender-suffix=${env.JOB_NAME.replace(' ', '_')}"];
-
-   _sendToAlertlib(subject, severity, body, extraFlags);
-}
-
-
-// Supported options:
 // when (required): under what circumstances to send to bugtracker; a list.
 //    Possible values are SUCCESS, FAILURE, UNSTABLE, or BACK TO NORMAL.
 //    (Used in call(), below.)


### PR DESCRIPTION
## Summary:
Looking over the alertlib code, I noticed that the secrets that
alertlib needs to send email -- sendgrid_username and
sendgrid_password -- do not exist in secrets.py, and possibly haven't
for a long time.  This means that sending to email would never work.
Given that, in jenkins, we only use send-to-email mode for two jobs
and then only on failure, and given that those jobs haven't failed in
months and months, it's possible that this feature hasn't worked for a
long time and we never noticed.  (Especially since the email goes to
jenkins-admin, which as far as I know I'm the only one who ever looks
at it.)

So let's just get rid of this feature, and depend to sending to slack
on failure.  That seems to have been working well so far.

I considered trying to fix send-to-email instead, by restoring these
sendgrid secrets to secrets.py.  But I couldn't find the secrets in
either gsm or keeper.  Rather than try to track them down or do other
heroic efforts to revive this feature, I think it's better just to let
it Rest In Peace.

Issue: none

## Test plan:
Will run on jenkins.