### PR TITLE
[🔥AUDIT🔥] Don't decrypt secrets for uploading the graphql-safelist.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -496,15 +496,13 @@ def uploadGraphqlSafelist() {
    // for uploading its own queries to the safelist.
    if (SERVICES.any { it != 'static'}) {
       echo("Uploading GraphQL queries to the safelist.");
-      withSecrets() {
-         dir("webapp") {
-            exec([
-               "python",
-               "deploy/upload_graphql_safelist.py",
-               NEW_VERSION,
-               "--prod",
-            ])
-         }
+      dir("webapp") {
+         exec([
+            "python",
+            "deploy/upload_graphql_safelist.py",
+            NEW_VERSION,
+            "--prod",
+         ])
       }
    }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I rewrote the deploy script to get the secret directly from gsm, so it
doesn't need secrets.py.

Issue: None

## Test plan:
Will do a test deploy on jenkins