### PR TITLE
[🔥AUDIT🔥] Add secrets in another place we send to slack.

### DIFF
--- a/jobs/deploy-fastly.groovy
+++ b/jobs/deploy-fastly.groovy
@@ -112,6 +112,7 @@ def ensureUpToDate() {
 
 def deploy() {
    withTimeout('15m') {
+      withSecrets.slackAlertlibOnly() { // to report to #fastly
       dir("webapp/services/fastly-khanacademy") {
          // `make deploy` uses vt100 escape codes to color its diffs,
          // let's make sure they show up properly.
@@ -124,7 +125,7 @@ def deploy() {
 
 def setDefault() {
    withTimeout('5m') {
-      withSecrets.slackAlertlibOnly() { // to report to #whats-happening
+      withSecrets.slackAlertlibOnly() { // report to #fastly, #whats-happening
          dir("webapp/services/fastly-khanacademy") {
             sh(params.TARGET == "prod" ? "make set-default" : "make set-default-test");
          }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In fastly, we send to slack at deploy time, not just set-default time.
I don't know how I missed that before.

Issue: none

## Test plan:
Will try a fastly deploy