### PR TITLE
[🔥AUDIT🔥] Decrypt both slack and stackdriver secrets, in two places.

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -572,7 +572,10 @@ def _promoteServices() {  // call from webapp-root
     }
 
     cmd += [services.join(",")];
-    withSecrets.slackAlertlibOnly() { // because we set --slack-channel
+    // We talk to slack (you can tell via the --slack-channel arg above),
+    // but we also talk to stackdriver to tell it monitoring statistics.
+    // So we need both secrets.
+    withSecrets.slackAndStackdriverAlertlibOnly() {
        exec(cmd);
     }
 }
@@ -617,7 +620,10 @@ def _monitor() {
           "--slack-channel=${SLACK_CHANNEL}",
           "--monitor-error-is-fatal"];
       dir("webapp") {
-      withSecrets.slackAlertlibOnly() { // because we set --slack-channel
+      // We talk to slack (you can tell via the --slack-channel arg above),
+      // but we also talk to stackdriver to tell it monitoring statistics.
+      // So we need both secrets.
+      withSecrets.slackAndStackdriverAlertlibOnly() {
          try {
             exec(cmd);
          } catch (e) {

--- a/vars/withSecrets.groovy
+++ b/vars/withSecrets.groovy
@@ -9,6 +9,7 @@ import groovy.transform.Field
 // TODO(benkraft): Make sure updates to this are actually atomic.
 @Field _activeSecretsBlocks = 0;
 @Field _activeSlackSecretsBlocks = 0;
+@Field _activeSlackAndStackdriverSecretsBlocks = 0;
 @Field _activeGithubSecretsBlocks = 0;
 
 def _secretsPasswordPath() {
@@ -53,7 +54,7 @@ def slackAlertlibOnly(Closure body) {
       sh("gcloud --project khan-academy secrets versions access latest --secret Slack__API_token_for_alertlib >decrypted_secrets/slack/secrets.py");
       sh("perl -pli -e 's/^/slack_alertlib_api_token = \"/; s/\$/\"/' decrypted_secrets/slack/secrets.py");
       sh("chmod 600 decrypted_secrets/slack/secrets.py");
-      _activeSecretsBlocks++;
+      _activeSlackSecretsBlocks++;
 
       // Then, tell alertlib where secrets live, and run the wrapped block.
       withEnv(["ALERTLIB_SECRETS_DIR=${pwd()}/decrypted_secrets/slack"]) {
@@ -78,7 +79,7 @@ def githubAlertlibOnly(Closure body) {
       sh("gcloud --project khan-academy secrets versions access latest --secret khan_actions_bot_github_personal_access_token__Repository_Status___Deployments__repo_status__repo_deployment__ >decrypted_secrets/github/secrets.py");
       sh("perl -pli -e 's/^/github_repo_status_deployment_pat = \"/; s/\$/\"/' decrypted_secrets/github/secrets.py");
       sh("chmod 600 decrypted_secrets/github/secrets.py");
-      _activeSecretsBlocks++;
+      _activeGithubSecretsBlocks++;
 
       // Then, tell alertlib where secrets live, and run the wrapped block.
       withEnv(["ALERTLIB_SECRETS_DIR=${pwd()}/decrypted_secrets/github"]) {
@@ -93,3 +94,32 @@ def githubAlertlibOnly(Closure body) {
       }
    }
 }
+
+// This must be called from workspace-root.  While this is in scope,
+// *only* the slack secret is available, even if there's a higher-up
+// call to withSecrets().
+def slackAndStackdriverAlertlibOnly(Closure body) {
+   try {
+      sh("mkdir -p decrypted_secrets/slack_and_stackdriver/");
+      sh("gcloud --project khan-academy secrets versions access latest --secret Slack__API_token_for_alertlib >decrypted_secrets/slack_and_stackdriver/secrets.py");
+      sh("perl -pli -e 's/^/slack_alertlib_api_token = \"/; s/\$/\"/' decrypted_secrets/slack_and_stackdriver/secrets.py");
+      sh("echo google_alertlib_service_account = \\'\\'\\' >>decrypted_secrets/slack_and_stackdriver/secrets.py");
+      sh("gcloud --project khan-academy secrets versions access latest --secret google_api_service_account__for_alertlib_ >>decrypted_secrets/slack_and_stackdriver/secrets.py");      
+      sh("echo \\'\\'\\' >>decrypted_secrets/slack_and_stackdriver/secrets.py");
+      sh("chmod 600 decrypted_secrets/slack_and_stackdriver/secrets.py");
+      _activeSlackAndStackdriverSecretsBlocks++;
+
+      // Then, tell alertlib where secrets live, and run the wrapped block.
+      withEnv(["ALERTLIB_SECRETS_DIR=${pwd()}/decrypted_secrets/slack_and_stackdriver"]) {
+         body();
+      }
+   } finally {
+      _activeSlackAndStackdriverSecretsBlocks--;
+      // Finally, iff we're exiting the last slackAlertlibOnly block,
+      // clean up our secret.
+      if (!_activeSlackAndStackdriverSecretsBlocks) {
+         sh("rm -f decrypted_secrets/slack/");
+      }
+   }
+}
+


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
There are a couple of scripts we run that send data to stackdriver:
monitoring and set-default.  Let's make sure they have the secrets
they need.

While writing this I discovered a bug in how we were accounting for
how the secrests blocks were being used, meaning that we weren't
deleting secrets-files when we were done with them, like we were
supposed to.  I fixed that up too.

Issue: None

## Test plan:
Will try a deploy