### PR TITLE
Added logic to detect and alert of potentially stuck deployment jobs

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -208,6 +208,14 @@ NEW_VERSION = null;
 alertMsgs = null;
 
 
+// Sometimes jobs that are aborted by a user don't really abort because
+// Jenkins job is in an uninterruptible status. Most likely due the abort
+// happened while the job is making an HTTP request. In those case, we will
+// throw this exception to really really abort the jobs to prevent getting
+// stuck with jobs not aborting.
+public class AbortDeployJob extends Exception {}
+
+
 @NonCPS     // for replaceAll()
 def _interpolateString(def s, def interpolationArgs) {
    // Arguments to replaceAll().  `all` is the entire regexp match,
@@ -260,6 +268,21 @@ def _alert(def slackArgs, def interpolationArgs) {
       args += ["--slack-attachments=${attachmentString}"];
    }
    withSecrets.slackAlertlibOnly() {
+      sh("echo ${exec.shellEscape(msg)} | ${exec.shellEscapeList(args)}");
+   }
+}
+
+// TODO(miguel): remove once we are done monitoring hanging deploys.
+def _simpleSlackAlert(def channel, def msg, def severity) {
+   args = ["jenkins-jobs/alertlib/alert.py",
+           "--slack=${channel}",
+           "--chat-sender=Mr Anderson",
+           "--icon-emoji=:crying-nickcage:",
+           "--slack-simple-message",
+           "--severity=${severity}",
+          ];
+   withSecrets.slackAlertlibOnly() {     // to talk to slack
+      echo("sending slack message")
       sh("echo ${exec.shellEscape(msg)} | ${exec.shellEscapeList(args)}");
    }
 }
@@ -519,12 +542,74 @@ def _manualPromptCheck(prompt){
    return;
 }
 
+// This funciton will check if the state of the current job has changed
+// but somehow the thread is still running. So we will throw an exception
+// to trigger the jobs to abort. Let the caller decide if this exception
+// should bubble up the stack or not.
+def _maybeAbortJob(oldBuildResult, newBuildResult, reason) {
+   // NOTE(miguel): Build status changed, let's check if the job was
+   // aborted.  We should not be in an aborted state here but we have a
+   // theory that the job was aborted but jenkins did not successfully
+   // abort the thread because it was in the middle of uninterruptible
+   // work like making an HTTP request. If that's the case we are going
+   // to cause the job to abort from here to prevent new deploy-webapp
+   // jobs from getting stuck.
+   if (oldBuildResult != newBuildResult) {
+      // Because this is a theory that build are getting stuck because the
+      // signal to abort the current thread while we are in an uninterruptible
+      // cycle, we are not 100% sure what the correct things to check are
+      // to make an exact desicion. So we are going to log a message to slack
+      // to keep track of these cases.
+      _simpleSlackAlert(
+         "#infrastructure-deploys",
+         """Deploy aborted but thread is still running. We most likely have a 
+job that is stuck. ${reason}. prev state ${oldBuildResult}. current state 
+${newBuildResult}. ${env.BUILD_URL}. 
+See https://khanacademy.atlassian.net/wiki/spaces/INFRA/pages/2470543393/Stuck+jenkins+deploy-webapp+builds 
+for details to get information about stuck builds. cc @deploy-support""",
+         "error",
+      )
+
+      if (newBuildResult == "ABORTED") {
+         // Jenkins would throw a hudson.AbortException.  But to make
+         // things more clear that the job is aborting itself we will
+         // throw a different exception.  This exception will (should)
+         // be handle by the caller to ensure we clean things up.
+         // TODO(miguel): enable once we are confident this will work.
+         // Let's run it without auto aborting to get some ideas so that
+         // we don't mistakenly start aborting false positives.
+         // throw new AbortDeployJob("Deploy was aborted. " + reason)
+      }
+   }
+}
+
 // TODO(jacqueline): Make this a shared func with verifying smoke tests.
 def verifyPromptConfirmed(prompt, buildmasterFailures=0) {
+   if (currentBuild.result == "ABORTED") {
+      // TODO(miguel): perhaps throw exception once we understand better why
+      // we got into this function with an aborted job.
+      echo("Job is aborted but we are still trying to verify prompt status "+
+           "${prompt}. That's not great at all. Ping @deploy-support to "+
+           "take a look.")
+   }
+
    def status;
    while (status != "confirmed") {
+      def buildResult = currentBuild.result
       status = buildmaster.pingForPromptStatus(prompt,
                                                params.GIT_REVISION)
+
+      _maybeAbortJob(
+         buildResult,
+         currentBuild.result,
+         "Build status changed while talking to buildmaster.",
+      )
+
+      // Because we want to know if the status of the build changed at
+      // different points in this logic, we need to keep track of the
+      // status of the job before meaningful actions such as before and
+      // after an HTTP request happens or before and after the thread sleeps
+      buildResult = currentBuild.result
 
       // If sun is down (even after a retry), we ask people to manually
       // check the result of their smoke tests.
@@ -549,6 +634,12 @@ def verifyPromptConfirmed(prompt, buildmasterFailures=0) {
       // Continue pinging every 10 seconds until the prompt is confirmed
       if (status in ["unacknowledged", "acknowledged"]) {
         sleep(10);
+
+         _maybeAbortJob(
+            buildResult,
+            currentBuild.result,
+            "Build status changed while the thread was sleeping.",
+         )
       }
    }
    return;


### PR DESCRIPTION
## Summary:
We are having random deploy jobs getting stuck causing all sorts of nasty issues in the deploy queue with seeming stuck jobs after a user has abort their deployment. The theory is that abort signals from jenkins to threads are not working because the threads are in uninterruptible cycles.  To help us determine this I have added slack alerts to the `#infrastructure-deploys` channel to let us know that we pontentially have deploy-webapp jobs that are stuck.

I have added logic to trigger an abort but I have it disabled to start with to ensure that we have the correct logic in place before potentially start to abort jobs that shouldn't be.  Once this is out and we can test it, we can enable the logic to abort build that we deem "stuck".

Issue: https://khanacademy.atlassian.net/browse/INFRA-9495

## Test plan:
Monitor the deploy and verify that we don't have deploy jobs suddenly aborting.  Icing on the cake, try to reproduce the stuck aborted jobs to test the slack logging logic.

1. queue a deploy.
2. when asked to `set default` by sun, monitor your deploy-webapp job and try to abort when we are making the request to buildmaster to get the `prompt-status`.
3. If the job is stuck, then we will keep looping asking for the prompt-status.
4. Check #infrastucture-deploys channel for informational message about the deploy.

This is pretty tricky to reproduce... And best done when nobody is in the queue.