### PR TITLE
Make sure we check for abort every time we catch an exception.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -233,6 +233,7 @@ def runTestServer() {
       unstash(name: "test-info.db before");
       sh("touch test-info.db.lock");   // split_tests.py needs this too
    } catch (e) {
+      notify.rethrowIfAborted(e);
       // Proceed anyway -- perhaps the file doesn't exist yet.
       // Ah well; we'll just serve tests in a slightly sub-optimal order.
       echo("Unable to restore test-db from server, won't sort tests by time: ${e}");
@@ -319,6 +320,7 @@ def runTestServer() {
          unstash(name: "test-info.db after");
       }
    } catch (e) {
+      notify.rethrowIfAborted(e);
       // Oh well; hopefully another job will do better.
       echo("Unable to push test-db back to server: ${e}");
    }
@@ -400,6 +402,7 @@ def runTestWorker(workerId) {
                "--upload-file", "junit.xml",
                "${TEST_SERVER_URL}/end?filename=junit-${workerId}.xml"]);
       } catch (e) {
+         notify.rethrowIfAborted(e);
          echo("Error sending junit results to /end: ${e}");
          // Better to not pass a junit file than to not /end at all.
          try {

--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -79,8 +79,7 @@ def _makeHttpRequestAndAlert(resource, httpMode, params) {
             return response;
          }
       } catch (e) {
-         // Ideally, we'd just catch hudson.AbortException, but for some reason
-         // it's not being caught properly.
+         notify.rethrowIfAborted(e);
          // httpRequest throws exceptions when buildmaster responds with status
          // code >=400
          echo("Error talking to buildmaster [${resource}]: ${e}");

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -4,6 +4,7 @@
 
 // We use these user-defined steps from vars/:
 //import vars.exec
+//import vars.notify
 //import vars.withSecrets
 
 // Turn a list of submodules into arguments to pass to safe_git.sh functions.
@@ -82,6 +83,7 @@ def wasSyncedTo(repo, commit, syncFn) {
       actual = readFile(_buildTagFile(repo));
       return actual == "${syncFn} ${commit} ${env.BUILD_TAG}";
    } catch (e) {
+      notify.rethrowIfAborted(e);
       return false;     // build_tag file was just deleted.
    }
 }
@@ -219,6 +221,7 @@ def mergeBranches(gitRevisions, tagName) {
                exec(["git", "merge", branchSha1]);
             }
          } catch (e) {
+            notify.rethrowIfAborted(e);
             // TODO(benkraft): Also send the output of the merge command that
             // failed.
             notify.fail("Failed to merge ${branchSha1} into " +

--- a/vars/retry.groovy
+++ b/vars/retry.groovy
@@ -1,3 +1,6 @@
+// We use these user-defined steps from vars/:
+//import vars.notify
+
 def call(options=null, Closure body) {
    options = options ?: [:];
    def retryCount = options.retryCount ?: 3;
@@ -6,6 +9,7 @@ def call(options=null, Closure body) {
       try {
          return body();
       } catch (e) {
+         notify.rethrowIfAborted(e);
          def msgStart = "Try #${i}: got ${e}."
          if (i == retryCount) {
             echo("${msgStart} Giving up.");


### PR DESCRIPTION
## Summary:
If a jenkins job is aborted, every process gets passed an
AbortException.  But it's possible to swallow that exception if your
code is in a try/catch.

This PR looks at every `catch` in our codebase, and if the `catch`
doesn't always rethrow anyway, I add a call to a function that checks
if the job has been aborted, and if so rethrows the exception (which
is presumably AbortException).

That should resolve issues like
https://jenkins.khanacademy.org/job/deploy/job/deploy-webapp/16256
where a job got aborted but stuff kept on running anyway, because the
`notify.log()` function swallowed the abort exception.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9495

## Test plan:
Am mostly just concerned this doesn't break anything; we'll have to
land it and see.