### PR TITLE
[🔥AUDIT🔥] Print class name for exceptions in notify.log

### DIFF
--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -386,7 +386,7 @@ def log(message, args=[:]) {
       sh(shellCommand);
    } catch (e) {
       // We never want logging itself to cause a build to fail.
-      echo("Logging to Google Cloud Logging failed: ${e.getMessage()}.  Continuing.");
+      echo("Logging to Google Cloud Logging failed: ${e.getClass().getName()} - ${e.getMessage()}.  Continuing.");
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We have a theory that the call to gcloud is throwing an exception in notify.log when jenkins is aborting a job, but the exception message is null. And there is no clear way to know what exception was thrown. So I am including the class name for the exception being thrown hoping to help us verify the theory.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9495

## Test plan:
This one is hard to reproduce, so hoping we can see the message when a job is stuck which we are reporting in `#infrastructure-deploys`