### PR TITLE
Hnadle the case where the deploy-username isn't set.

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -211,6 +211,9 @@ def getUserIds(def deployUsernameBlob) {
    // W (special users), T (teams), or C (channels).
    def pattern = /<@([UTWC][0-9A-Z]+)>/;
    def match = (deployUsernameBlob =~ pattern);
+   if (match.results().count() == 0) {
+        return ""
+   }
 
    def mainUser = match[0][1];
    def otherUsers = "";
@@ -268,7 +271,7 @@ def analyzeResults() {
 
             // Include the deployer(s) here so they can get DMs when the e2e
             // results are ready.
-            def ccAlways = "#cypress-logs-deploys,${userIds}";
+            def ccAlways = userIds ? "#cypress-logs-deploys,${userIds}" : "#cypress-logs-deploys";
 
             if (params.SLACK_CHANNEL != "#qa-log") {
                ccAlways += ",#qa-log";


### PR DESCRIPTION
## Summary:
The deploy-username is set when the e2e tests are run by jenkins, but
not when run by hand.  Let's make sure the script gracefully handles
that case.

Issue: https://jenkins.khanacademy.org/job/deploy/job/e2e-test/53606/console

## Test plan:
I replayed job 53606 (as 53607) with this new code, and it passed.