### PR TITLE
[🔥AUDIT🔥] Fix the gcloud account we try to run our network-config backups as.

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -297,7 +297,7 @@ backup_network_config() {
     (
         cd network-config
         make deps
-        make ACCOUNT=storage-read@khanacademy.org CONFIG=$HOME/s3-reader.cfg PROFILE=default GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-service-account.json
+        make ACCOUNT=stackdriver-service-account@khan-academy.iam.gserviceaccount.com CONFIG=$HOME/s3-reader.cfg PROFILE=default GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-service-account.json
         git add .
     )
     # The subshell lists every directory we have a Makefile in.


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We used to use prod-read, but I think that account went away.  Now we
use the service account associated with the existing
gcloud-service-account.json file.

I hope (expect) this service account has all the permissions we need.
In general, we're not very good about limiting permissions for service
accounts.

Issue: none

## Test plan:
Ran
```
make -C stackdriver ACCOUNT=stackdriver-service-account@khan-academy.iam.gserviceaccount.com
```
on jenkins-server in the webapp-maintenance job directory, and got no
access errors.