### PR TITLE
[🔥AUDIT🔥] Do not pass the `--deployer` flag when no deployer is known.

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -251,9 +251,6 @@ def analyzeResults() {
                "--channel", params.SLACK_CHANNEL,
                // The URL associated to this Jenkins build.
                "--build-url", env.BUILD_URL,
-               // The deployer is the person who triggered the build (this is
-               // only included in the message if the e2e tests fail).
-               "--deployer", params.DEPLOYER_USERNAME,
                // The LambdaTest build name that will be included at the
                // beginning of the message.
                "--label", BUILD_NAME,
@@ -263,6 +260,12 @@ def analyzeResults() {
                "--cc-on-failure", "#deploy-support-log"
             ];
 
+            if (params.DEPLOYER_USERNAME) {
+               // The deployer is the person who triggered the
+               // build (this is only included in the message if
+               // the e2e tests fail).
+               notifyResultsArgs += ["--deployer", params.DEPLOYER_USERNAME];
+            }
             if (params.SLACK_THREAD) {
                notifyResultsArgs += ["--thread", params.SLACK_THREAD];
             }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
notify-e2e-results.ts is ok with `--deployer` being missing, but
not with it being the empty string.

Issue: https://jenkins.khanacademy.org/job/deploy/job/e2e-test/53611/console

## Test plan:
groovy jobs/e2e-test.groovy