### PR TITLE
[🔥AUDIT🔥] Make sure jenkins-server runs as prod-deploy@.

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -297,7 +297,7 @@ backup_network_config() {
     (
         cd network-config
         make deps
-        make ACCOUNT=stackdriver-service-account@khan-academy.iam.gserviceaccount.com CONFIG=$HOME/s3-reader.cfg PROFILE=default GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-service-account.json
+        make CONFIG=$HOME/s3-reader.cfg PROFILE=default GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-service-account.json
         git add .
     )
     # The subshell lists every directory we have a Makefile in.


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I had activated a service-account in #169, but I didn't realize that
this command makes that service-account the default for all gcloud
operations.  We still want the default to be done as
prod-deploy@khanacademy.org!  And only use the service-account with
the `--account` flag.  This new command does that.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1698352831330619

## Test plan:
Ran the command manually on jenkins-server with success.