### PR TITLE
[🔥AUDIT🔥] Redo how we track failed jobs in weekly-maintenace.sh.

### DIFF
--- a/weekly-maintenance.sh
+++ b/weekly-maintenance.sh
@@ -372,12 +372,15 @@ jenkins-jobs/safe_git.sh sync_to_origin "git@github.com:Khan/network-config" "ma
 ( cd webapp && make deps python_deps )
 
 
+# We have to do things this weird way because you can't modify a
+# variable inside a for/do.
 failed_jobs=""
 for job in $jobs_to_run; do
     (
         echo "--- Starting $job: `date`"
-        $job
+        $job && rc=0 || rc=$?
         echo "--- Finished $job: `date`"
+        exit $rc  # exits the subshell, not the whole job!
     ) || failed_jobs="$failed_jobs $job"
 done
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The backup_network job was failing, but the script wasn't reporting
that it failed.  This is because a subshell exits with the result of
the lsat command, which in this case is an `echo` which always
suceeds.  Fix that.

Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/268/execution/node/910/log/

## Test plan:
Fingers crossed