### PR TITLE
[🔥AUDIT🔥] Work around a gsutil bug when cleaning ka-translations.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -114,7 +114,9 @@ clean_ka_translations() {
     for dir in `gsutil ls gs://ka_translations`; do
         # Ignore the "raw" dir, which isn't a language.
         [ "$dir" = "gs://ka_translations/raw/" ] && continue
-        versions=`gsutil ls $dir | sort`
+        # Sometimes the `ls` lists the directory itself.  I think that's
+        # a bug in gsutil, but let's just work around it.
+        versions=`gsutil ls $dir | grep -v "^$dir$" | sort`
         # We keep all version-dirs that fit either of these criteria:
         # 1) One of the last 3 versions
         # 2) version was created within the last week


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Sometimes the `gsutil ls <dir>` command lists the directory itself.  I
think that's a bug in gsutil -- it occurs in the gsutil installed with
gcloud 419, but not with gcloud 452 -- but it's easy enough to work
around it, so let's just do that.

Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/272/execution/node/264/log/

## Test plan:
Ran the command manually with success.