### PR TITLE
[🔥AUDIT🔥] There's another `raw` directory in ka-translations now.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -114,6 +114,7 @@ clean_ka_translations() {
     for dir in `gsutil ls gs://ka_translations`; do
         # Ignore the "raw" dir, which isn't a language.
         [ "$dir" = "gs://ka_translations/raw/" ] && continue
+        [ "$dir" = "gs://ka_translations/raw_TESTING/" ] && continue
         # Sometimes the `ls` lists the directory itself.  I think that's
         # a bug in gsutil, but let's just work around it.
         versions=`gsutil ls $dir | grep -v "^$dir$" | sort`


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/273/consoleFull

## Test plan:
Fingers crossed, will try running the job again.