### PR TITLE
[🔥AUDIT🔥] Secrets for alertlib in deploy to go script

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -553,10 +553,12 @@ def deployToGatewayConfig() {
 
 // This should be called from within a node().
 def deployToService(service) {
-   dir("webapp") {
-      exec(["make", "-C", "services/${service}", "deploy",
-            "ALREADY_RAN_TESTS=1",
-            "DEPLOY_VERSION=${NEW_VERSION}"]);
+   withSecrets.slackAndStackdriverAlertlibOnly() {
+      dir("webapp") {
+         exec(["make", "-C", "services/${service}", "deploy",
+               "ALREADY_RAN_TESTS=1",
+               "DEPLOY_VERSION=${NEW_VERSION}"]);
+      }
    }
 }
 

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -241,10 +241,12 @@ def deployToGCS() {
 
 // This should be called from within a node().
 def deployToService(service) {
-   dir("webapp") {
-      exec(["make", "-C", "services/${service}", "deploy",
-            "ALREADY_RAN_TESTS=1",
-            "DEPLOY_VERSION=${VERSION}"]);
+   withSecrets.slackAndStackdriverAlertlibOnly() {
+      dir("webapp") {
+         exec(["make", "-C", "services/${service}", "deploy",
+               "ALREADY_RAN_TESTS=1",
+               "DEPLOY_VERSION=${VERSION}"]);
+      }
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We have enabled writing deploy metrics to stackdriver here https://github.com/Khan/webapp/pull/18161.  And that needs secrets so that alert lib can write to stackdriver. So that's what Im wiring on up in this audit.

Error message from jenkins logs:
```
13:15:03  Deployed service [recommendations] to [https://231120-1000-bfca1ab5c368-dot-recommendations-dot-khan-academy.appspot.com/]
13:15:03  
13:15:03  You can stream logs from the command line by running:
13:15:03    $ gcloud app logs tail -s recommendations
13:15:03  
13:15:03  To view your application in the web browser run:
13:15:03    $ gcloud app browse -s recommendations --project=khan-academy
13:15:03  [2023-11-20 18:15:00,815 INFO] Service recommendations version 231120-1000-bfca1ab5c368. Deployment completed. 314.99 seconds.
13:15:03  Traceback (most recent call last):
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/deploy/deploy_go_service.py", line 591, in <module>
13:15:03      args.force_appengine, args.force_cloud_run, args.dry_run)
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/deploy/deploy_go_service.py", line 550, in main
13:15:03      service_name, version, promote, bucket, dry_run)
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/deploy/deploy_go_service.py", line 455, in deploy_to_appengine
13:15:03      "version": version})
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/third_party/vendored/third_party/alertlib/stackdriver.py", line 256, in send_to_stackdriver
13:15:03      ignore_errors)
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/third_party/vendored/third_party/alertlib/stackdriver.py", line 168, in send_datapoints_to_stackdriver
13:15:03      client = _get_google_apiclient(google_creds)
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/third_party/vendored/third_party/alertlib/stackdriver.py", line 44, in _get_google_apiclient
13:15:03      ['https://www.googleapis.com/auth/monitoring']))
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/third_party/vendored/third_party/oauth2client/service_account.py", line 253, in from_json_keyfile_dict
13:15:03      revoke_uri=revoke_uri)
13:15:03    File "/home/ubuntu/webapp-workspace/webapp/third_party/vendored/third_party/oauth2client/service_account.py", line 172, in _from_parsed_json_keyfile
13:15:03      'Expected', client.SERVICE_ACCOUNT)
13:15:03  ValueError: ('Unexpected credentials type', None, 'Expected', 'service_account')
13:15:03  make: *** [../Makefile.inc:320: default_deploy] Error 1
13:15:03  make: Leaving directory '/home/ubuntu/webapp-workspace/webapp/services/recommendations'
```

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1700250956435529?thread_ts=1700250652.052659&cid=C096UP7D0

## Test plan:
Run a deployment and ensure we can write to stackdriver.