### PR TITLE
[🔥AUDIT🔥] Let the update-devserver-images job take longer.  A lot longer.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -1,4 +1,4 @@
-// The pipeline job to update the dev-server static images in gcloud.
+// The pipeline job to update the dev-server images in gcloud.
 //
 // When called (which we expect to be every day), this job rebuilds
 // all the images that we use for local dev-server -- one for each
@@ -31,7 +31,7 @@ the updated data-file to it.""",
    "#infrastructure"
 
 ).addCronSchedule(
-   '0 2 * * *'
+   '0 22 * * *'
 
 ).apply();
 
@@ -67,7 +67,7 @@ def publishResults() {
 }
 
 
-onMaster('2h') {
+onMaster('10h') {
    notify([slack: [channel: params.SLACK_CHANNEL,
                    sender: 'Devserver Duck',
                    emoji: ':duck:',


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Now that we're cross-compiling all our Go binaries on arm, using
emulation, it can take like 20 minutes to build the containers for a
single service.  So let's give it 10 hours to finish totally.

(A better solution is to use cross-compilation instead of emulation,
but that is a task for another day.)

Issue: none

## Test plan:
Fingers crossed