### PR TITLE
[🔥AUDIT🔥] Abort stuck webapp deploy jenkin's jobs

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -575,10 +575,7 @@ for details to get information about stuck builds. cc @deploy-support""",
          // things more clear that the job is aborting itself we will
          // throw a different exception.  This exception will (should)
          // be handle by the caller to ensure we clean things up.
-         // TODO(miguel): enable once we are confident this will work.
-         // Let's run it without auto aborting to get some ideas so that
-         // we don't mistakenly start aborting false positives.
-         // throw new AbortDeployJob("Deploy was aborted. " + reason)
+         throw new AbortDeployJob("Deploy was aborted. " + reason)
       }
    }
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We have been monitoring webapp-deploy jenkins jobs that get stuck. This happens when someone in the front of the deploy queue aborts their deploy while jenkins is waiting for them to `set default`.  The issue seems to happen when we call `sh` to write to gcloud logs...

I had added logic in https://github.com/Khan/jenkins-jobs/pull/162 to tell us when the error happens by sending us a message in slack.  I had commented out the logic to throw an exception whenever we detect that the job was aborted while waiting for the `set default` prompt.  But now that I know the logic is correct, Im enabling the exception to abort the job if its stuck.

This should get us over the hump for now... I am also adding logging around the `sh` call to verify our theory.  If it turns out to be true, then the plan is to add a wrapper for `sh` that can check the status of the job when the call the `sh` is done.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9495

## Test plan:
Deploy and wait for the slack message I added around the problematic `sh` call to tell us when a job is stuck.  If we get a confirmation hit, then I can add a `safeSh` type of function.