### PR TITLE
[🔥AUDIT🔥] Add more precise abort check

### DIFF
--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -395,7 +395,8 @@ def log(message, args=[:]) {
 
       // TODO(miguel): remove this whole check once we confirm this is the
       // the problem spot.
-      if (currentResult != currentBuild.result) {
+      def newResult = currentBuild.result
+      if (currentResult != newResult && newResult == "ABORTED") {
          // We have been dealing with aborted jobs getting stuck.  Traces point
          // to `sh` calls not throwing exceptions when aborting jobs, so we
          // want to verify that theory.  This particular case we are after is


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I added some logic in https://github.com/Khan/jenkins-jobs/pull/181 to send a message to slack if a job was aborted while in a call to `sh` and `sh` never throws an exception that aborts the jenkins job.  In this follow up change I am making the check more precise to ensure the job is in the `ABORTED` state.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9495

## Test plan:
groovy vars/notify.groovy