### PR TITLE
[🔥AUDIT🔥] Just run upload-images.sh directly to upload images, rather than using make.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -48,7 +48,7 @@ def runScript() {
       sh("make fix_deps");  // force a remake of all deps all the time
 
       // Run the script!
-      sh("make -C dev/server upload-all-static-images");
+      sh("dev/server/upload-images.sh");
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The upload-images.sh script has been in master for a while now.

Issue: none

## Test plan:
Will run this jenkins job manually.