### PR TITLE
[🔥AUDIT🔥] Run update-devserver-static-images on a worker machine.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -67,7 +67,10 @@ def publishResults() {
 }
 
 
-onMaster('10h') {
+// TODO(csilvers): move back to running this on master after we figure
+// out why, on master, the docker network bridge is so flaky.  See
+// https://khanacademy.slack.com/archives/C3UDL9QN7/p1701536113469519
+onWorker('build-worker', '10h') {
    notify([slack: [channel: params.SLACK_CHANNEL,
                    sender: 'Devserver Duck',
                    emoji: ':duck:',


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It would be better to run on jenkins-server, so we could reuse the
docker caches from day to day, but I keep getting failures due to the
docker network connection going down.  I don't know why.  The jenkins
workers seem to be more reliable in my limited testing, so I'm going
with those instead.

Issue: https://khanacademy.slack.com/archives/C3UDL9QN7/p1701536113469519

## Test plan:
Will run this job