### PR TITLE
[🔥AUDIT🔥] Pass the `--no-tags` flag to upload-images.sh.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -65,7 +65,7 @@ def uploadService(service) {
       // but unpredictably) fails with:
       // ERROR: failed to receive status: rpc error: code = Unavailable desc = error reading from server: EOF
       retry(5) {
-         exec(["dev/server/upload-images.sh", service]);
+         exec(["dev/server/upload-images.sh", "--no-tags", service]);
       }
    }
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This jenkins job calls upload-images.sh a few dozen times, once for
each service.  By default, in each run upload-images.sh would create a
symlink-tag for all the services that are _not_ being deployed in that
run.  But we don't want a symlink-tag for those other services, since
they're going to be deployed for real in their turn, and will get a
real tag at that time.  Without this flag, the symlink-tags and real
tags will fight each other.

Issue: none

## Test plan:
Will try running it.