### PR TITLE
Remove all references to deploying to GAE from the jenkins jobs.

### DIFF
--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -26,8 +26,7 @@ spaces. Must exactly match the name of an existing version (e.g.
 
 ).addStringParam(
     "MODULES",
-    """The modules to delete, comma-separated.  By default we delete all the
-"webapp" modules.""",
+    """The modules to delete, comma-separated.  Must not be empty.""",
     ""
 
 ).apply();

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -1,4 +1,4 @@
-// Send live traffic to a new (static or dynamic) version of webapp.
+// Send live traffic to a new version of webapp.
 
 // Sending traffic to a version is a complex process, and this is a complex
 // script.  For more high-level information on deploys, see
@@ -72,13 +72,12 @@ new Setup(steps
     """<p>A comma-separated list of services we wish to change to the new
 version (see below for options), or the special value "auto", which says to
 choose the services to set-default automatically based on what files have
-changed.  For example, you might specify "dynamic,static" to force setting
-default on both GAE and GCS.</p>
+changed.  For example, you might specify "users,static" to force setting
+default on both the users service and GCS.</p>
 
 <p>Here some less-obvious service names:</p>
 <ul>
   <li> <b>static</b>: The static (e.g. browser js) service. </li>
-  <li> <b>dynamic</b>: The dynamic (e.g. python-code) service. </li>
 </ul>
 
 <p>You can specify the empty string to do no version-switching, like if you

--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -102,27 +102,12 @@ def doSetup() {
 // not intended. Someone can run this without the params if they
 // want to rely on the defaults.
 def verifyValidTag(tag) {
-   // A full version tag should always include the dynamic version, which will
-   // be listed first. We strip everything else (e.g. 181217-1330-b18f83d38a3d)
    if (!tag.contains('gae')) {
-      notify.fail("Version tag should always include the " +
-                  "dynamic version. To see all potential tags, " +
-                  "use `git tag -l 'gae-*'.");
+      notify.fail("Version tag should always start with `gae-`. " +
+                  "To see all potential tags, use `git tag -l 'gae-*'.");
    }
-   def dynamic = exec.outputOf(["webapp/deploy/git_tags.py",
-                                "--service=dynamic", "--parse", tag]);
-   // Check that the dynamic version in fact exists on GAE
-   def args = ["gcloud", "app", "versions", "list",
-               "--project=khan-academy", "--service=default",
-               "--filter=version.name:${dynamic}"];
-   def gae_version = exec.outputOf(args);
-   // when a version is not found, gcloud returns "Listed 0 items."
-   if (!gae_version.contains(dynamic)) {
-      notify.fail("Version gae-${dynamic} not found. " +
-                  "Check versions that exist on GAE using: " +
-                  "`${args}`");
-   }
-   _alert("Confirmed that ${dynamic} is a valid version!");
+   // TODO(csilvers): do more.
+   _alert("${tag} seems to be a valid tag");
    return true;
 }
 

--- a/vars/onMaster.txt
+++ b/vars/onMaster.txt
@@ -3,8 +3,7 @@ Same as `node("master")` but does a bunch of executor-specific setup too.
 1. It makes sure jenkins-jobs is available in the current workspace
    (almost every node needs jenkins-jobs to do further checkouts).
 2. It enables virtualenv (for python scripts)
-3. It enables access to secrets.py [optional]
-4. It turns on timestamping of all commands run on that node.
+3. It turns on timestamping of all commands run on that node.
 
 This should normally be wrapped around `notify()`, which will wrap the
 actual job logic.  See also `onWorker()`, if you don't want to run on master.

--- a/vars/onWorker.txt
+++ b/vars/onWorker.txt
@@ -3,9 +3,8 @@ Same as `node(<label>)` but does a bunch of executor-specific setup too.
 1. It makes sure jenkins-jobs is available in the current workspace
    (almost every node needs jenkins-jobs to do further checkouts).
 2. It enables virtualenv (for python scripts)
-3. It enables access to secrets.py [optional]
-4. It turns on timestamping of all commands run on that node.
-5. It runs all of this in workspace shared across jobs.
+3. It turns on timestamping of all commands run on that node.
+4. It runs all of this in workspace shared across jobs.
 
 If the entire job runs on a worker, you should wrap this around a `notify()`
 call, and put the rest of your job inside.  If only some of the job runs on a

--- a/vars/withSecrets.groovy
+++ b/vars/withSecrets.groovy
@@ -7,43 +7,9 @@ import groovy.transform.Field
 // TODO(benkraft): In principle this should be per-directory; in practice
 // assuming we're always in the same directory is good enough at present.
 // TODO(benkraft): Make sure updates to this are actually atomic.
-@Field _activeSecretsBlocks = 0;
 @Field _activeSlackSecretsBlocks = 0;
 @Field _activeSlackAndStackdriverSecretsBlocks = 0;
 @Field _activeGithubSecretsBlocks = 0;
-
-def _secretsPasswordPath() {
-   return "${env.HOME}/secrets_py/secrets.py.aes.password";
-}
-
-// This must be called from workspace-root.
-def call(Closure body) {
-   try {
-      // First, set up secrets.
-      // This decryption command was modified from the make target
-      // "secrets_decrypt" in the webapp project.
-      // Note that we do this even if ACTIVE_SECRETS_BLOCKS > 0;
-      // secrets.py.aes might have changed.
-      exec(["openssl", "aes-256-cbc", "-d", "-md", "sha256", "-salt",
-            "-in", "webapp/shared/secrets.py.aes",
-            "-out", "webapp/shared/secrets.py",
-            "-kfile", _secretsPasswordPath()]);
-      sh("chmod 600 webapp/shared/secrets.py");
-      _activeSecretsBlocks++;
-
-      // Then, tell alertlib where secrets live, and run the wrapped block.
-      withEnv(["ALERTLIB_SECRETS_DIR=${pwd()}/webapp/shared"]) {
-         body();
-      }
-   } finally {
-      _activeSecretsBlocks--;
-      // Finally, iff we're exiting the last withSecrets block, clean up
-      // secrets.py so if the next job intends to run without secrets, it does.
-      if (!_activeSecretsBlocks) {
-         sh("rm -f webapp/shared/secrets.py webapp/shared/secrets.pyc");
-      }
-   }
-}
 
 // This must be called from workspace-root.  While this is in scope,
 // *only* the slack secret is available, even if there's a higher-up

--- a/vars/withSecrets.txt
+++ b/vars/withSecrets.txt
@@ -1,10 +1,13 @@
-Decrypts secrets.py in the webapp-root.
+Decrypts secrets needed to call alertlib in different modes.
 
 It must be called while the current directory is the workspace-root.
 
-NOTE(benkraft): withSecrets is leaky; other branches of the same job will see
-the secrets file too, even if they are not in a withSecrets block.
+This decrypts some secrets needed by alertlib and stores them in a
+file where alertlib looks for secrets.
 
-We also provide the ability to just decrypt one secret: the slack
-secret that alertlib needs to talk to slack.  It is a surprisingly
-common case that that is the only secret we need for a given use.
+The most common case is to decrypt just the secret needed to talk to
+slack.  Here are all the cases:
+
+* slackAlertlibOnly
+* githubAlertlibOnly
+* slackAndStackdriverAlertlibOnly


### PR DESCRIPTION
## Summary:
Ever since https://github.com/Khan/webapp/pull/11178, Jenkins has not
deployed the dynamic (python2) service unless specifically asked to do
so via something like `sun: deploy mybranch (SERVICES=dynamic)`.  But
the code to deploy to default still existed.

This PR rips it out.  Way out!  Because the SAT service has been
sunset (sunsetted?), and there is no code running on these services
anymore.  If you ask to deploy the `dynamic` service you'll just get
an error.

This should wait until after 1 Jan 2024 to land, since that's when
the SAT product is formally sunset(ted).

Issue: https://khanacademy.atlassian.net/browse/INFRA-9701

## Test plan:
groovy jobs/build-webapp.groovy