### PR TITLE
[🔥AUDIT🔥] Changed infrastructure-devops channel to infrastructure-platform

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -314,12 +314,12 @@ def _userIdsFrom(def deployUsernameBlob) {
 // understand why a deployment was aborted. Also sends it to
 // #dev-support-stream so we can follow up on 'missed' surveys.
 //
-// #infrastructure: <#C8Y4Q1E0J>
+// #infrastructure-platform: <#C01120CNCS0>
 def _sendAbortedDeploymentSurvey() {
     def msg = ":robot_hearthands: It looks like you recently aborted a " +
         "deployment. If there is still work to do for monitoring, please do " +
         "that *BEFORE* responding to this message. However, when you have a " +
-        "few minutes <#C8Y4Q1E0J> would appreciate if you could fill out this " +
+        "few minutes <#C01120CNCS0> would appreciate if you could fill out this " +
         "short survey to help us understand what happened. Your response " +
         "helps us refine the deployment system. " +
         "<https://docs.google.com/forms/d/e/1FAIpQLSczr-9iOrdI1kaFNCAamoLMJ1cDGehURFpLV-OMcHSLIa3Rkg/viewform?usp=pp_url&entry.1550451339=${BUILD_NUMBER}|click me>";
@@ -701,7 +701,7 @@ def _monitor() {
           "--monitor=${params.MONITORING_TIME}",
           "--slack-channel=${SLACK_CHANNEL}",
           "--monitor-error-is-fatal"];
-      dir("webapp") {
+   dir("webapp") {
       // We talk to slack (you can tell via the --slack-channel arg above),
       // but we also talk to stackdriver to tell it monitoring statistics.
       // So we need both secrets.

--- a/jobs/deploy-webapp_slackmsgs.groovy
+++ b/jobs/deploy-webapp_slackmsgs.groovy
@@ -38,7 +38,7 @@
 // Slack teams and channels (copy and paste one of these into your message if
 // you need to link/mention):
 //
-// #infrastructure: <#C8Y4Q1E0J>
+// #infrastructure-platform: <#C01120CNCS0>
 // #release-notes: <#C2RFQGYKU>
 // @deploy-support: <!subteam^S05M3QU7WJE>
 // @dev-support: <!subteam^S41PPSJ21>
@@ -138,7 +138,7 @@ FAILED_MERGE_TO_MASTER = [
    "text": _textWrap("""\
 :ohnoes: Deploy of `%(combinedVersion)s` (branch `%(branch)s`)
 succeeded, but we did not successfully merge `%(branch)s` into
-`master`. <#C8Y4Q1E0J> will need to fix things up, or
+`master`. <#C01120CNCS0> will need to fix things up, or
 see "Advanced Troubleshooting" in the deploy system user guide.
 """)];
 
@@ -175,7 +175,7 @@ BUILDMASTER_OUTAGE = [
 :ohnoes: Jenkins is unable to reach buildmaster right now while trying to verify
 that %(step)s. You'll want to check the <%(logsUrl)s|jenkins logs> directly to
 tell Jenkins to proceed.
-Perhaps buildmaster is down. <#C8Y4Q1E0J> should look into it.
+Perhaps buildmaster is down. <#C01120CNCS0> should look into it.
 """)];
 
 return this;


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We have been slowly phasing out the infrastructure-devops channel and changing it to infrastructure-platform.  A couple of messages we send from jenkins reference the infrastructure-devops channel, so Im changing it to infrastructure-platform.

Issue: "none"

## Test plan:
Wait for jenkins errors trying to communicate with buildmaster