### PR TITLE
Temporarily disable first smoke tests

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -300,6 +300,9 @@ def analyzeResults() {
 }
 
 
+// Determines if we are running the first or second smoke test.
+E2E_RUN_TYPE = (E2E_URL == "https://www.khanacademy.org" ? "second-smoke-test" : "first-smoke-test");
+
 onWorker(WORKER_TYPE, '5h') {     // timeout
    notify([slack: [channel: params.SLACK_CHANNEL,
                    thread: params.SLACK_THREAD,
@@ -307,24 +310,30 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
                    emoji: ':turtle:',
                    when: ['FAILURE', 'UNSTABLE']],
            buildmaster: [sha: params.GIT_REVISION,
-                         what: (E2E_URL == "https://www.khanacademy.org" ?
-                                'second-smoke-test': 'first-smoke-test')]]) {
+                         what: E2E_RUN_TYPE]]) {
 
-      stage("Sync webapp") {
-         _setupWebapp();
-      }
-
-      try {
-         stage("Run e2e tests") {
-            runLambdaTest();
+      // NOTE(juan): This is a temporary hack to notify the buildmaster that
+      // we are done with the first smoke test. This is needed because of some
+      // issues with our E2E testing infrastructure.
+      if (E2E_RUN_TYPE == "first-smoke-test") {
+         // send signal to buildmaster.
+         echo("Notifying buildmaster that we are done with first smoke test");
+      } else {
+         stage("Sync webapp") {
+            _setupWebapp();
          }
-      } finally {
-         // We want to analyze results even if -- especially if -- there were
-         // failures; hence we're in the `finally`.
-         stage("Analyzing results") {
-            analyzeResults();
+
+         try {
+            stage("Run e2e tests") {
+               runLambdaTest();
+            }
+         } finally {
+            // We want to analyze results even if -- especially if -- there were
+            // failures; hence we're in the `finally`.
+            stage("Analyzing results") {
+               analyzeResults();
+            }
          }
       }
-
    }
 }

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -313,14 +313,14 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
                          what: E2E_RUN_TYPE]]) {
 
       if (E2E_RUN_TYPE == "first-smoke-test") {
-         // NOTE(juan): This is a temporary hack to just not run first
-       // smoke tests.  This is needed because some issues with our E2E testing
-       // infrastructure are causing smoketests to take a very long time to run,
-       // so we can't afford to run two of them for every deploy.  We skip the
-       // first smoke test because it takes the longer of the two (since
-       // pre-default webapp isn't as well primed).
-       echo("Temporarily skipping first smoke tests");
-       return;
+         // NOTE(juan): This is a temporary hack to just not run first smoke
+         // tests.  This is needed because some issues with our E2E testing
+         // infrastructure are causing smoketests to take a very long time to
+         // run, so we can't afford to run two of them for every deploy.  We
+         // skip the first smoke test because it takes the longer of the two
+         // (since pre-default webapp isn't as well primed).
+         echo("Temporarily skipping first smoke tests");
+         return;
       }
 
       stage("Sync webapp") {


### PR DESCRIPTION
## Summary:

This is a temporary measure while we investigate the cause of the slowness in
our e2e testing infra.

Issue: XXX-XXXX

## Test plan:

Verify that this replay worked as expected:

- First smoke test: https://jenkins.khanacademy.org/job/deploy/job/e2e-test/55630/console