### PR TITLE
Revert change that disabled first smoke tests

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -312,17 +312,6 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
            buildmaster: [sha: params.GIT_REVISION,
                          what: E2E_RUN_TYPE]]) {
 
-      if (E2E_RUN_TYPE == "first-smoke-test") {
-         // NOTE(juan): This is a temporary hack to just not run first smoke
-         // tests.  This is needed because some issues with our E2E testing
-         // infrastructure are causing smoketests to take a very long time to
-         // run, so we can't afford to run two of them for every deploy.  We
-         // skip the first smoke test because it takes the longer of the two
-         // (since pre-default webapp isn't as well primed).
-         echo("Temporarily skipping first smoke tests");
-         return;
-      }
-
       stage("Sync webapp") {
          _setupWebapp();
       }


### PR DESCRIPTION
## Summary:

After disabling the first smoke tests (#191), we've seen that the LambdaTest
infra is more stable. This gives us confidence that the first smoke tests are
back to how they were working before.

This PR reverts the change that skipped the first smoke tests and instead runs
the regular flow in the e2e-tests job.

Issue: XXX-XXXX

## Test plan:

N/A