### PR TITLE
[🔥AUDIT🔥] Have jenkins-cleaning delete `third_party/__init__.pyc`.

### DIFF
--- a/vars/clean.groovy
+++ b/vars/clean.groovy
@@ -28,6 +28,9 @@ def call(howClean) {
       // genfiles is excluded from "git clean" so we need to manually
       // remove artifacts that should not be kept across builds.
       sh("rm -rf genfiles/test-reports genfiles/lint_errors.txt");
+      // This is (well, used to be) our only contentful .pyc file.
+      // If it sticks around when it shouldn't, that could cause problems.
+      sh("rm -rf third_party/__init__.pyc")
 
    } else if (howClean == "none") {
       // No need to do anything!


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This file is a special case: `third_party/__init__.py` used to be our
only contentful python init-file.  Then we deleted it.  But the .pyc
file isn't under git control, so it can only get deleted by a "clean"
call.  If we don't delete it, then it's still run whenever someone
imports something under third-party, which can cause trouble.  So now
we delete it even in the light-cleaning mode.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1705697611608769?thread_ts=1705696301.913349&cid=C096UP7D0

## Test plan:
groovy vars/clean.groovy