### PR TITLE
Improve e2e instrumentation

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -183,6 +183,7 @@ def runLambdaTest() {
                             "-p=${params.NUM_WORKER_MACHINES}",
                             "--sync=true",
                             "--bt='jenkins,${e2eEnv}'",
+                            "--tags='jenkins,${e2eEnv}'",
                             "--eof"
    ];
 
@@ -256,8 +257,8 @@ def analyzeResults() {
                "--label", BUILD_NAME,
                // The URL we test against.
                "--url", params.URL,
-               // Notify failures to DevOps
-               "--cc-on-failure", "#deploy-support-log"
+               // Notify failures to DevOps and FEI
+               "--cc-on-failure", "#deploy-support-log,#fei-testing-logs"
             ];
 
             if (params.DEPLOYER_USERNAME) {


### PR DESCRIPTION
## Summary:

This PR improves the e2e instrumentation by slightly changing the way we build
our e2e tests:

1. Adding tags to each spec, so we can easily filter them out in the future via
the Dashboard UI or the API.
2. Notifying to the #fei-testing-logs slack channel in case of "first/second
smoke test" failures.

Issue: XXX-XXXX

## Test plan:

Verify that the e2e tests are still running as expected and that the tags are
included in the test results.