### PR TITLE
Add support for enabling the python3 virtualenv when running jobs.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -40,6 +40,7 @@ import org.khanacademy.Setup;
 //import vars.onWorker
 //import vars.withSecrets
 //import vars.withTimeout
+//import vars.withVirtualenv
 
 
 def formatServicesList(services) {
@@ -674,17 +675,23 @@ onWorker('build-worker', '4h') {
 
       try {
          stage("Merging in master") {
-            mergeFromMasterAndInitializeGlobals();
+            withVirtualenv.python3() {
+               mergeFromMasterAndInitializeGlobals();
+             }
          }
          stage("Deploying") {
             withTimeout('150m') {
-               deployAndReport();
+               withVirtualenv.python3() {
+                  deployAndReport();
+               }
             }
          }
          // TODO(jacqueline): This may get spammy. Is there somewhere we can
          // move this so that it doesn't send for every build?
          stage("Send changelog") {
-            sendChangelog();
+            withVirtualenv.python3() {
+               sendChangelog();
+            }
          }
       } catch (e) {
          echo("FATAL ERROR deploying: ${e}");

--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -8,6 +8,7 @@ import org.khanacademy.Setup;
 //import vars.kaGit
 //import vars.notify
 //import vars.withTimeout
+//import vars.withVirtualenv
 
 
 new Setup(steps
@@ -68,7 +69,9 @@ onMaster('30m') {
                 when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       verifyArgs();
       stage("Deleting") {
-         deleteVersion();
+         withVirtualenv.python3() {
+            deleteVersion();
+         }
       }
    }
 }

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -50,6 +50,7 @@ import org.khanacademy.Setup;
 //import vars.notify
 //import vars.withSecrets
 //import vars.withTimeout
+//import vars.withVirtualenv
 
 
 // We do not allow concurrent builds; this should in theory also be enforced by
@@ -940,11 +941,15 @@ onMaster('4h') {
                          what: 'deploy-webapp']]) {
       try {
          stage("Merging in master") {
-            mergeFromMasterAndInitializeGlobals();
+            withVirtualenv.python3() {
+               mergeFromMasterAndInitializeGlobals();
+            }
          }
       } catch (e) {
             echo("FATAL ERROR merging in master: ${e}");
-            finishWithFailure(e.toString());
+            withVirtualenv.python3() {
+               finishWithFailure(e.toString());
+            }
             throw e;
       }
 
@@ -966,7 +971,9 @@ onMaster('4h') {
       if (SERVICES) {
          try {
             stage("Promoting and monitoring") {
-               setDefaultAndMonitor();
+               withVirtualenv.python3() {
+                  setDefaultAndMonitor();
+               }
             }
             // Unlike above, we do not need to verify second smoke tests
             // have finished. Buildmaster does that for us before prompting
@@ -976,7 +983,9 @@ onMaster('4h') {
             }
          } catch (e) {
             echo("FATAL ERROR promoting and monitoring and prompting: ${e}");
-            finishWithFailure(e.toString());
+            withVirtualenv.python3() {
+               finishWithFailure(e.toString());
+            }
             throw e;
          }
       }

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -15,6 +15,7 @@ import org.khanacademy.Setup;
 //import vars.onWorker
 //import vars.withSecrets
 //import vars.withTimeout
+//import vars.withVirtualenv
 
 
 new Setup(steps
@@ -451,7 +452,9 @@ onWorker('znd-worker', '3h') {
                    when: ['BUILD START','FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       determineVersion();
       stage("Deploying") {
-         deploy();
+         withVirtualenv.python3() {
+            deploy();
+         }
       }
    }
 }

--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -19,6 +19,7 @@ import org.khanacademy.Setup;
 //import vars.notify
 //import vars.withSecrets
 //import vars.withTimeout
+//import vars.withVirtualenv
 
 // We try to keep minimal options in this job: you don't want to have to
 // figure out which options are right when the site is down!
@@ -148,12 +149,14 @@ onMaster('1h') {
                    emoji: ':monkey_face:',
                    when: ['BUILD START', 'SUCCESS',
                           'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
-       stage("setup") {
-           doSetup();
-       }
-       stage("rollback") {
-           doRollback();
-       }
+      stage("setup") {
+         doSetup();
+      }
+      stage("rollback") {
+         withVirtualenv.python3() {
+            doRollback();
+         }
+      }
    }
    // Let's kick off the e2e tests again to make sure everything is
    // working ok.

--- a/jobs/find-failing-taskqueue-tasks.groovy
+++ b/jobs/find-failing-taskqueue-tasks.groovy
@@ -7,6 +7,7 @@ import org.khanacademy.Setup;
 //import vars.kaGit
 //import vars.notify
 //import vars.withSecrets
+//import vars.withVirtualenv
 
 
 new Setup(steps
@@ -31,9 +32,11 @@ onMaster('1h') {
          kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", "master");
          sh("make -C webapp python_deps")
          withSecrets.slackAlertlibOnly() {  // because we pass --slack-channel
-            dir("webapp") {
-               exec(["dev/tools/failing_taskqueue_tasks.py",
-                     "--slack-channel=${params.SLACK_CHANNEL}"]);
+            withVirtualenv.python3() {
+               dir("webapp") {
+                  exec(["dev/tools/failing_taskqueue_tasks.py",
+                        "--slack-channel=${params.SLACK_CHANNEL}"]);
+               }
             }
          }
       }

--- a/jobs/notify-znd-owners.groovy
+++ b/jobs/notify-znd-owners.groovy
@@ -18,6 +18,7 @@ import org.khanacademy.Setup;
 //import vars.notify
 //import vars.withSecrets
 //import vars.withTimeout
+//import vars.withVirtualenv
 
 
 // The simplest setup ever! -- we only want the defaults.
@@ -44,7 +45,9 @@ onMaster('1h') {
                    emoji: ':monkey_face:',
                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Notifying") {
-         runScript();
+         withVirtualenv.python3() {
+            runScript();
+         }
       }
    }
 }

--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -12,6 +12,7 @@ import org.khanacademy.Setup;
 //import vars.kaGit
 //import vars.notify
 //import vars.withTimeout
+//import vars.withVirtualenv
 
 
 new Setup(steps
@@ -75,7 +76,9 @@ onMaster('2h') {
                    emoji: ':turtle:',
                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Run script") {
-         runScript();
+         withVirtualenv.python3() {
+            runScript();
+         }
       }
       stage("Publish results") {
          publishResults();

--- a/vars/withVirtualenv.groovy
+++ b/vars/withVirtualenv.groovy
@@ -12,7 +12,7 @@ def call(Closure body) {
    if (env.VIRTUAL_ENV && fileExists(env.VIRTUAL_ENV)) {
       // we're already in a virtualenv.  The fileExists is necessary
       // because a node can inherit the environment from its parent
-      // and have an inaccuarte VIRTUAL_ENV.
+      // and have an inaccurate VIRTUAL_ENV.
       echo("(Not activating virtualenv; already active at ${env.VIRTUAL_ENV})");
       // Make sure the virtual-env is still first in the path.
       withEnv(["PATH=${env.VIRTUAL_ENV}/bin:${env.PATH}"]) {
@@ -60,6 +60,18 @@ For more information, see https://wiki.python.org/moin/DebuggingWithGdb
    withEnv(["VIRTUAL_ENV=${pwd()}/env",
             "PATH=${pwd()}/env/bin:${env.PATH}"]) {
       _maybeDowngradePip();
+      body();
+   }
+}
+
+// NOTE: it is safe to have both the above and below active at the same
+// time.  `python2` binaries will use the virtualenv from call(), and
+// `python3` binaries will use the virtual from here.
+// This must be called from workspace-root.
+def python3(Closure body) {
+   echo("Activating python3 virtualenv");
+   sh("make -C webapp/deploy deps");
+   withEnv(["PATH=${pwd()}/webapp/deploy/venv/bin:${env.PATH}"]) {
       body();
    }
 }

--- a/vars/withVirtualenv.txt
+++ b/vars/withVirtualenv.txt
@@ -1,7 +1,20 @@
-This pipeline step runs its body in a python virtualenv.
+This pipeline step runs its body in a python2 virtualenv.
 
 This means that every python command run inside it will use the
 virtualenv rather than the system python/etc.
 
 It is not typically used manually -- onMaster/etc use it automatically
 as needed.
+
+There is also a python3() function which sets up a virtualenv to run
+python3 scripts.  This is webapp-specific, and uses the virtualenv in
+webapp's deploy/Makefile.  This typically *is* used manually, when
+making calls to the deploy and test scripts that use the top-level
+python3 virtualenv in webapp.
+
+Note it is possible to have both the python2 and python3 virtualenvs
+active at the same time!  In that world, running a binary under
+`python2` will use the python2 virtualenv, and `python3` will use the
+python3 virtualenv.  They will fight over the `python` binary, so
+don't use that.  (We are careful that all our webapp scripts
+explicitly say `python2` or `python3` for that reason.)


### PR DESCRIPTION
## Summary:
We are porting our deploy and testing scripts from python2 to python3.
Some of them need third-party libraries such as `requests` or
`graphql`, which we are supporting via a python3 virtualenv that is
constructed in webapp's deploy/Makefile.

This PR adds Jenkins support to use that virtualenv.  We don't have a
user-friendly way to enable the virtualenv -- we don't expect users to
run these scripts, just Jenkins -- but the new
`withVirtualenv.python3()` does all the needful.

I had a choice: I could set up this new virtualenv in onWorker() and
onMaster(), like we do with the python2 virtualenv, or I could require
jobs to call it manually to set it up in the places where it's needed.
I chose to do the latter, since our goal is to replace all our python3
with Go (or js) over time, and I'm hoping that will allow us to remove
these calls as that happens, and eventually be left with no
withVirtualenv calls at all.  That is easier to do one at a time than
when it's globally done in onMaster/onWorker.

It does make it harder to know when to call the new python3() call,
since we need to make sure we're on the right machine when we do it.
For now, that's only an issue with webapp-test.groovy, which runs
across a lot of machines.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9701

Test plan:

I ran `groovy` on all the files in this commit, with only the normal,
expected errors around `@CPS` and the like.