### PR TITLE
[🔥AUDIT🔥] Allow stashing and unstashing of test-info.db.json files.

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -227,7 +227,7 @@ def runTestServer() {
    // Try to load the server's test-info db.
    try {
       onMaster('1m') {
-         stash(includes: "test-info.db", name: "test-info.db before");
+         stash(includes: "test-info.db*", name: "test-info.db before");
       }
       sh("rm -f test-info.db");
       unstash(name: "test-info.db before");
@@ -315,7 +315,7 @@ def runTestServer() {
 
    // The server updated test-info.db as it ran.  Let's store the updates!
    try {
-      stash(includes: "test-info.db", name: "test-info.db after");
+      stash(includes: "test-info.db*", name: "test-info.db after");
       onMaster('1m') {
          unstash(name: "test-info.db after");
       }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In #19440 I will be renaming the test-info files to be
test-info.db.json.  Let's change the webapp-test job to support both
naming formats.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9702

## Test plan:
Fingers crossed, will run tests on the `redo-timing-db` branch and
check jenkins-server:~jenkins/jobs/deploy/jobs/webapp-test/workspace
and see if test-info.db.json is there.