### PR TITLE
Remove args that just don't get used

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -181,8 +181,7 @@ def runLambdaTest() {
                             "--cy='--config baseUrl=\"${E2E_URL}\",retries=${params.TEST_RETRIES}'",
                             "--bn='${BUILD_NAME}'",
                             "-p=${params.NUM_WORKER_MACHINES}",
-                            "--bt='jenkins,${e2eEnv}'",
-                            "--tags='jenkins,${e2eEnv}'"
+                            "--bt='jenkins,${e2eEnv}'"
    ];
 
    dir('webapp/services/static') {

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -181,10 +181,8 @@ def runLambdaTest() {
                             "--cy='--config baseUrl=\"${E2E_URL}\",retries=${params.TEST_RETRIES}'",
                             "--bn='${BUILD_NAME}'",
                             "-p=${params.NUM_WORKER_MACHINES}",
-                            "--sync=true",
                             "--bt='jenkins,${e2eEnv}'",
-                            "--tags='jenkins,${e2eEnv}'",
-                            "--eof"
+                            "--tags='jenkins,${e2eEnv}'"
    ];
 
    dir('webapp/services/static') {


### PR DESCRIPTION
## Summary:
The removed args don't do anything - they aren't passed along to the CLI invocation because we manage that stuff internally.

These are the args we support: https://github.com/Khan/webapp/blob/04b6b63ae70d1969427140601b0961e9540cb93f/services/static/dev/cypress/e2e/util/parse-lambdatest-arguments.ts#L34-L42

Related change for webapp GitHub actions: https://github.com/Khan/webapp/pull/19586

Issue: FEI-5354

## Test plan:
There's nothing to test really - these args were already noops disappearing into the ether. However, on putting this change into rotation, we will see that all still works and nothing changed.