### PR TITLE
[🔥AUDIT🔥] No longer call some python scripts with "python".

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -396,10 +396,7 @@ def deployToGCS() {
 
    withSecrets.slackAlertlibOnly() {  // because we pass --slack-channel
       dir("webapp") {
-         // We use python -u to get maximally unbuffered output.
-         // TODO(csilvers): remove the ulimit; we don't need it now that
-         // we don't use kake anymore.
-         sh("ulimit -S -n 4096; python -u ${exec.shellEscapeList(args)}");
+         exec(args);
       }
    }
 }

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -190,12 +190,7 @@ def deployToGCS() {
 
    withSecrets.slackAlertlibOnly() {  // Because we set --slack-channel
       dir("webapp") {
-         // Increase the the maximum number of open file descriptors.
-         // This is necessary because kake keeps a lockfile open for
-         // every file it's compiling, and that can easily be
-         // thousands of files.  4096 is as much as linux allows.
-         // We also use python -u to get maximally unbuffered output.
-         sh("ulimit -S -n 4096; python -u ${exec.shellEscapeList(args)}");
+         exec(args)
       }
    }
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
As we transition to python3, we can't be sure which version to run,
from the groovy file.  Let's let the shebang line on the script tell
us.

That means we don't get `python -u` (unbuffered output) anymore, but I
don't think we need it anymore either.  At least, I hope...

Issue: https://jenkins.khanacademy.org/job/deploy/job/build-webapp/46494/execution/node/206/log/

## Test plan:
Fingers crossed