### PR TITLE
[🔥AUDIT🔥] Do not say "python" to run python binaries.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -463,7 +463,6 @@ def uploadGraphqlSafelist() {
       echo("Uploading GraphQL queries to the safelist.");
       dir("webapp") {
          exec([
-            "python",
             "deploy/upload_graphql_safelist.py",
             NEW_VERSION,
             "--prod",


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
As we transition to python3, we can't be sure which version to run,
from the groovy file.  Let's let the shebang line on the script tell
us.

I tried to fix this in #202 but missed a case.

Issue: https://jenkins.khanacademy.org/job/deploy/job/build-webapp/46496/execution/node/425/log/

## Test plan:
Fingers crossed