### PR TITLE
Fixed check if git shas are a branch name or not

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -368,7 +368,7 @@ def mergeFromMasterAndInitializeGlobals() {
          // TODO(benkraft): Verify it's actually a valid sha in this repo.
          // (We could write kaGit.isSha.)  This is a little tricky because
          // we may not yet have cloned the repo.
-         if (!params.GIT_REVISION ==~ /[0-9a-fA-F]{40}/) {
+         if (!(params.GIT_REVISION ==~ /[0-9a-fA-F]{40}/)) {
             notify.fail("GIT_REVISION was not a sha!");
          }
 

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -270,7 +270,7 @@ def sendToBuildmaster(buildmasterOptions, status) {
    // Buildmaster only knows how to handle testing a single (non-abbreviated)
    // git-sha, not one or multiple branch-names.  If the job refers to
    // branches, exit.
-   if (!buildmasterOptions.sha ==~ /[0-9a-fA-F]{40}/) {
+   if (!(buildmasterOptions.sha ==~ /[0-9a-fA-F]{40}/)) {
       return;
    }
    def buildmasterStatus;


### PR DESCRIPTION
## Summary:
We have been getting for years an error that jenkins can't talk to buildmaster when running scheduled e2e tests.  The issue is that the e2e tests provide `master` as the git hash, which is good for jenkins to do its work.  But buildmaster only knows about hashes.  We have a check in place to ensure that when we provide something that is _NOT_ a hash, we don't talk to buildmaster.  But that's actually what Im fixing in these changes.

The errors we get in the request logs are actually not easy to find... https://console.cloud.google.com/logs/query;query=%22cdb93c4dfd5a826da095afe66dfec769%22;cursorTimestamp=2024-02-06T10:03:25.380529Z;aroundTime=2024-02-06T10:03:25.918112681Z;duration=PT30S?project=khan-internal-services

The copy of the trace in case you can't access the URL in the future.

```
{
insertId: "qi4fshgxj3ey5c6z"
jsonPayload: {
message: "Couldn't find master"
sourceLocation: {3}
trace: "projects/khan-internal-services/traces/cdb93c4dfd5a826da095afe66dfec769"
traceId: "cdb93c4dfd5a826da095afe66dfec769"
}
labels: {4}
logName: "projects/khan-internal-services/logs/stdout"
receiveTimestamp: "2024-02-06T10:03:29.028644484Z"
resource: {2}
severity: "WARNING"
timestamp: "2024-02-06T10:03:25.380213Z"
}
```

Issue: https://khanacademy.slack.com/archives/C21FZFL6R/p1707258715435239

## Test plan:
Kick off e2e tests using `master` as the git sha.

You can also do some testing yourself to verify the groovy behavior

```
groovy -e '
def branch = "master"
if (!(branch ==~ /[0-9a-fA-F]{40}/)) {
   println("===> not a hash!")
}

if (!branch ==~ /[0-9a-fA-F]{40}/) {
  println("===> should not be a hash!")
}

def hash = "e0970f9a3ebaeedec7fea2bd954c96ee2121bf22"
if (!(hash ==~ /[0-9a-fA-F]{40}/)) {
  print("====> we have a hash - we are good")
}

if (!hash ==~ /[0-9a-fA-F]{40}/) {
  print("====> we have a hash - we are good")
}
'
```