### PR TITLE
When downgrading the pip, make sure we're downgrading the one in the virtualenv.

### DIFF
--- a/vars/withVirtualenv.groovy
+++ b/vars/withVirtualenv.groovy
@@ -4,12 +4,12 @@
 // we are using an older pip.
 def _maybeDowngradePip() {
   // TODO(csilvers): check if the pip version is actually 20+ first.
-  sh("pip install -U 'pip<20' setuptools");
+  sh("${env.VIRTUAL_ENV}/bin/pip install -U 'pip<20' setuptools");
 }
 
 // This must be called from workspace-root.
 def call(Closure body) {
-   if (env.VIRTUAL_ENV && fileExists(env.VIRTUAL_ENV)) {
+   if (env.VIRTUAL_ENV && fileExists("${env.VIRTUAL_ENV}/bin/pip")) {
       // we're already in a virtualenv.  The fileExists is necessary
       // because a node can inherit the environment from its parent
       // and have an inaccurate VIRTUAL_ENV.


### PR DESCRIPTION
## Summary:
We're seeing pip at version 19 in the deploy (python3) virtualenv,
which shouldn't be happening!  We have an (unproven) theory that the
issue is that somehow our pip-downgrading is affecting that virtualenv
rather than the python2 virtualenv.  This PR should make that
impossible.

Issue: https://jenkins.khanacademy.org/job/deploy/job/build-webapp/lastFailedBuild/console

## Test plan:
Fingers way crossed