### PR TITLE
[🔥AUDIT🔥] Sync webapp before trying to load the python3 virtualenv

### DIFF
--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -42,9 +42,14 @@ def verifyArgs() {
 }
 
 
-def deleteVersion() {
+def _setupWebapp() {
    withTimeout('25m') {
       kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", "master");
+   }
+}
+
+def deleteVersion() {
+   withTimeout('25m') {
       dir("webapp") {
          sh("make python_deps");
          def args = (["deploy/delete_gae_versions.py"]
@@ -68,6 +73,9 @@ onMaster('30m') {
                 emoji: ':monkey_face:',
                 when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       verifyArgs();
+      stage("Initializing webapp") {
+         _setupWebapp();
+      }
       stage("Deleting") {
          withVirtualenv.python3() {
             deleteVersion();


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The py3 virtualenv configs live inside webapp, so we need to make sure
the webapp repo is present before we can set the virtualenv up!

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1707504348171789

## Test plan:
groovy jobs/delete-version.groovy