### PR TITLE
Set PATH up at the very beginning(ish) of `onMaster`.

### DIFF
--- a/vars/onMaster.groovy
+++ b/vars/onMaster.groovy
@@ -19,16 +19,16 @@ def call(timeoutString, Closure body) {
                "/home/ubuntu/google-cloud-sdk/bin:" +
                "${env.HOME}/go/bin:" +
                "${env.PATH}"]) {
-          notify.logNodeStart("master", timeoutString);
           timestamps {
+             notify.logNodeStart("master", timeoutString);
              kaGit.checkoutJenkinsTools();
              withTimeout(timeoutString) {
                  echo("Running on main jenkins-server");
                  withVirtualenv() {
                       body();
                  }
-                 notify.logNodeFinish("master", timeoutString, start);
              }
+             notify.logNodeFinish("master", timeoutString, start);
           }
       }
    }

--- a/vars/onMaster.groovy
+++ b/vars/onMaster.groovy
@@ -6,30 +6,30 @@
 def call(timeoutString, Closure body) {
    node("master") {
       start = new Date();
-      notify.logNodeStart("master", timeoutString);
-      timestamps {
-         kaGit.checkoutJenkinsTools();
-         withVirtualenv() {
-            withTimeout(timeoutString) {
-                echo("Running on main jenkins-server");
-                // TODO(csilvers): figure out how to get the worker
-                // to source the .bashrc like it did before.  Now I
-                // think it's inheriting the PATH from the parent instead.
-                // To export BOTO_CONFIG, for some reason, worker did not
-                // source the .profile or .bashrc anymore.
-                withEnv(["BOTO_CONFIG=${env.HOME}/.boto",
-                         "PATH=" +
-                         "/home/ubuntu/webapp-workspace/devtools/khan-linter/bin:" +
-                         "/var/lib/jenkins/repositories/khan-linter/bin" +
-                         "/usr/local/google_appengine:" +
-                         "/home/ubuntu/google-cloud-sdk/bin:" +
-                         "${env.HOME}/go/bin:" +
-                         "${env.PATH}"]) {
-                     body();
-                }
-            }
-         }
+      // TODO(csilvers): figure out how to get the worker
+      // to source the .bashrc like it did before.  Now I
+      // think it's inheriting the PATH from the parent instead.
+      // To export BOTO_CONFIG, for some reason, worker did not
+      // source the .profile or .bashrc anymore.
+      withEnv(["BOTO_CONFIG=${env.HOME}/.boto",
+               "PATH=" +
+               "/home/ubuntu/webapp-workspace/devtools/khan-linter/bin:" +
+               "/var/lib/jenkins/repositories/khan-linter/bin" +
+               "/usr/local/google_appengine:" +
+               "/home/ubuntu/google-cloud-sdk/bin:" +
+               "${env.HOME}/go/bin:" +
+               "${env.PATH}"]) {
+          notify.logNodeStart("master", timeoutString);
+          timestamps {
+             kaGit.checkoutJenkinsTools();
+             withTimeout(timeoutString) {
+                 echo("Running on main jenkins-server");
+                 withVirtualenv() {
+                      body();
+                 }
+                 notify.logNodeFinish("master", timeoutString, start);
+             }
+          }
       }
-      notify.logNodeFinish("master", timeoutString, start);
    }
 }

--- a/vars/onWorker.groovy
+++ b/vars/onWorker.groovy
@@ -50,8 +50,8 @@ def call(def label, def timeoutString, Closure body) {
                "/home/ubuntu/google-cloud-sdk/bin:" +
                "${env.HOME}/go/bin:" +
                "${env.PATH}"]) {
-          notify.logNodeStart(label, timeoutString);
           timestamps {
+             notify.logNodeStart(label, timeoutString);
              // We use a shared workspace for all jobs that are run on the
              // worker machines.
              dir("/home/ubuntu/webapp-workspace") {
@@ -72,9 +72,9 @@ def call(def label, def timeoutString, Closure body) {
                    withVirtualenv() {
                       body();
                    }
-                   notify.logNodeFinish(label, timeoutString, start);
                 }
              }
+             notify.logNodeFinish(label, timeoutString, start);
           }
       }
    }


### PR DESCRIPTION
## Summary:
It seems like jenkins jobs on jenkins-server inherit their environment
from the java process, which is started by upstart and has a very
limited PATH.

`onMaster` updates PATH before running the user-job, but before this
PR it did it after doing some of its bookkeeping.  And it turns out
some of that bookkeeping needs the PATH to correctly access gcloud.
This PR sets the path before that bookkeeping, so the gcloud command
can succeed.

I've changed onWorker as well to be consistent.  In fact, I rearranged
some commands so they're consistent for both onWorker and onMaster.
(In not-meaningful ways, e..g putting `logNodeFinish` inside the
`timestamps` on both of them, instead of inside on one and outside on
the other.)

This fixes the problem that some gcloud calls would give errors, e.g.
https://jenkins.khanacademy.org/job/misc/job/update-ownership-data/1746/execution/node/8/log/:
```
gcloud logging write --payload-type=json --severity=INFO jenkins {
    "hostname": "jenkins-server",
    "timeout": "2h",
    "label": "master",
    "buildmaster_deploy_id": null,
    "build_url": "https://jenkins.khanacademy.org/job/misc/job/update-ownership-data/1746/",
    "build_user": null,
    "build_number": "1746",
    "git_revision": null,
    "description": null,
    "job_name": "misc/update-ownership-data",
    "virtual_env": null,
    "home": "/var/lib/jenkins",
    "build_status": "starting",
    "message": "start work misc/update-ownership-data null 1746 2h master hostname=jenkins-server"
}
cannot create user data directory: /var/lib/jenkins/snap/google-cloud-sdk/424: Not a directory
```

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1707579113326079

## Test plan:
groovy vars/onMaster.groovy
groovy vars/onWorker.groovy