### PR TITLE
Do a better job of indicating task failures in the weekly-maintenance script.

### DIFF
--- a/jobs/webapp-maintenance.groovy
+++ b/jobs/webapp-maintenance.groovy
@@ -75,20 +75,13 @@ onMaster('10h') {
       for (def i = 0; i < jobs.size(); i++) {
          stage(jobs[i]) {
             withVirtualenv.python3() {
-               def rc = exec.statusOf(
-                  ["timeout", "10h", "jenkins-jobs/weekly-maintenance.sh", jobs[i]]);
-               if (rc != 0) {
-                  echo("${jobs[i]} failed with rc ${rc}");
-                  failed_jobs << jobs[i];
+               catchError(buildResult: "FAILURE", stageResult: "FAILURE",
+                          message: "${jobs[i]} failed") {
+                  exec(["timeout", "10h", "jenkins-jobs/weekly-maintenance.sh",
+                        jobs[i]]);
                }
             }
          }
       }
-
-     stage("Analyzing results") {
-        if (failed_jobs.size() > 0) {
-           notify.fail("These jobs failed: " + failed_jobs.join(" "))
-        }
-     }
    }
 }


### PR DESCRIPTION
## Summary:
This change makes it so each failing task has a red dot next to it on
the pipeline-steps page.  Before this, they all had green dots, and
you had to look at the message at the end of the job to figure out
which tasks had failed.

(Now there is no message at the end of the job, which is maybe a
regression in quality but I think the red dots will be more useful.)

Issue: none

## Test plan:
I manually re-ran this new code at
https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/293/console