### PR TITLE
[🔥AUDIT🔥] *Another* place we need to enable the virtualenv _after_ syncing webapp.

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -387,71 +387,73 @@ def mergeFromMasterAndInitializeGlobals() {
          }
       }
 
-      dir("webapp") {
-         clean(params.CLEAN);
-         sh("make python_deps");  // this script only uses python!
+      withVirtualenv.python3() {
+         dir("webapp") {
+            clean(params.CLEAN);
+            sh("make python_deps");  // this script only uses python!
 
-         // Let's do a sanity check.
-         def headSHA1 = exec.outputOf(["git", "rev-parse", "HEAD"]);
-         if (params.GIT_REVISION != headSHA1) {
-            notify.fail("Internal error: " +
-                        "HEAD does not point to the deploy-branch");
-         }
-
-         def shouldDeployArgs = ["deploy/should_deploy.py"];
-
-         // TODO(benkraft): Extract the resolution of services into a util
-         if (params.SERVICES == "auto") {
-            try {
-               SERVICES = exec.outputOf(shouldDeployArgs).split("\n");
-            } catch(e) {
-               notify.fail("Automatic detection of what to deploy failed. " +
-                           "You can likely work around this by setting " +
-                           "SERVICES on your deploy; see " +
-                           "${env.BUILD_URL}rebuild for documentation, and " +
-                           "`sun: help flags` for how to set it.  If you " +
-                           "aren't sure, ask dev-support for help!");
+            // Let's do a sanity check.
+            def headSHA1 = exec.outputOf(["git", "rev-parse", "HEAD"]);
+            if (params.GIT_REVISION != headSHA1) {
+               notify.fail("Internal error: " +
+                           "HEAD does not point to the deploy-branch");
             }
-         } else {
-            SERVICES = params.SERVICES.split(",");
-         }
-         if (SERVICES == [""]) {
-            // Either of the above could be [""], if we should deploy nothing.
-            // We want to use [] instead: [""] would mean deploying a single
-            // nameless service or something.
-            SERVICES = [];
-         }
-         echo("Deploying to the following services: ${SERVICES.join(', ')}");
 
-         NEW_VERSION = exec.outputOf(["make", "gae_version_name"]);
-         DEPLOY_URL = "https://prod-${NEW_VERSION}.khanacademy.org";
-         GIT_TAG = "gae-${NEW_VERSION}";
-
-         // Test coverage in webapp/deploy/git_tags_test.py DeployTagsTest
-         // mimics the git tag workflow used here. If any changes are made to
-         // the steps below, make the same changes there as well so we are
-         // testing the way our deploy git tagging works.
-         def currentVersionTag = exec.outputOf(
-            ["deploy/current_version.py", "--git-tag"]);
-         def currentVersionParts = exec.outputOf(
-            ["deploy/git_tags.py", "--parse", currentVersionTag]).split("\n");
-
-         // If this deploy fails, we want to roll back to the version
-         // that was active when the deploy started.  That's now!
-         ROLLBACK_TO = currentVersionTag;
-
-         // Construct a dict from service to version, using NEW_VERSION
-         // for any service in SERVICES.  We'll emit this in the git tag.
-         for (def i = 0; i < currentVersionParts.size(); i++) {
-            def serviceAndVersion = currentVersionParts[i];
-            if (serviceAndVersion) {
-               def service = serviceAndVersion.split("=")[0];
-               def oldVersion = serviceAndVersion.split("=")[1];
-               VERSION_DICT[service] = oldVersion;
+            // TODO(benkraft): Extract the resolution of services into a util
+            if (params.SERVICES == "auto") {
+               try {
+                  SERVICES = exec.outputOf(["deploy/should_deploy.py"]).split("\n");
+               } catch(e) {
+                  notify.fail("Automatic detection of what to deploy failed. " +
+                              "You can likely work around this by setting " +
+                              "SERVICES on your deploy; see " +
+                              "${env.BUILD_URL}rebuild for documentation, and " +
+                              "`sun: help flags` for how to set it.  If you " +
+                              "aren't sure, ask dev-support for help!");
+               }
+            } else {
+               SERVICES = params.SERVICES.split(",");
             }
-         }
-         for (def i = 0; i < SERVICES.size(); i++) {
-            VERSION_DICT[SERVICES[i]] = NEW_VERSION;  // I AM YELLING!
+            if (SERVICES == [""]) {
+               // Either of the above could be [""], if we should
+               // deploy nothing.  We want to use [] instead: [""]
+               // would mean deploying a single nameless service or
+               // something.
+               SERVICES = [];
+            }
+            echo("Deploying to the following services: ${SERVICES.join(', ')}");
+
+            NEW_VERSION = exec.outputOf(["make", "gae_version_name"]);
+            DEPLOY_URL = "https://prod-${NEW_VERSION}.khanacademy.org";
+            GIT_TAG = "gae-${NEW_VERSION}";
+
+            // Test coverage in webapp/deploy/git_tags_test.py
+            // DeployTagsTest mimics the git tag workflow used
+            // here. If any changes are made to the steps below, make
+            // the same changes there as well so we are testing the
+            // way our deploy git tagging works.
+            def currentVersionTag = exec.outputOf(
+               ["deploy/current_version.py", "--git-tag"]);
+            def currentVersionParts = exec.outputOf(
+               ["deploy/git_tags.py", "--parse", currentVersionTag]).split("\n");
+
+            // If this deploy fails, we want to roll back to the version
+            // that was active when the deploy started.  That's now!
+            ROLLBACK_TO = currentVersionTag;
+
+            // Construct a dict from service to version, using NEW_VERSION
+            // for any service in SERVICES.  We'll emit this in the git tag.
+            for (def i = 0; i < currentVersionParts.size(); i++) {
+               def serviceAndVersion = currentVersionParts[i];
+               if (serviceAndVersion) {
+                  def service = serviceAndVersion.split("=")[0];
+                  def oldVersion = serviceAndVersion.split("=")[1];
+                  VERSION_DICT[service] = oldVersion;
+               }
+            }
+            for (def i = 0; i < SERVICES.size(); i++) {
+               VERSION_DICT[SERVICES[i]] = NEW_VERSION;  // I AM YELLING!
+            }
          }
       }
    }
@@ -941,9 +943,7 @@ onMaster('4h') {
                          what: 'deploy-webapp']]) {
       try {
          stage("Merging in master") {
-            withVirtualenv.python3() {
-               mergeFromMasterAndInitializeGlobals();
-            }
+            mergeFromMasterAndInitializeGlobals();
          }
       } catch (e) {
             echo("FATAL ERROR merging in master: ${e}");


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In #208, and again in #212, I fixed jenkins jobs that were trying to
activate the python3 virtualenv before syncing webapp.  This could
fail because the py3 virtualenv configs live inside webapp, so we need
to make sure the webapp repo is present before we can set the
virtualenv up!

Well, it came up again.  This time it was more understandable, but
still.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1708113113843639

## Test plan:
grooyv jobs/deploy-webapp.groovy