### PR TITLE
Fail if there are lambdatest framework failures.

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -314,16 +314,17 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
          _setupWebapp();
       }
 
-      try {
-         stage("Run e2e tests") {
-            runLambdaTest();
-         }
-      } finally {
-         // We want to analyze results even if -- especially if -- there were
-         // failures; hence we're in the `finally`.
-         stage("Analyzing results") {
-            analyzeResults();
-         }
+      stage("Run e2e tests") {
+         // Note: runLambdaTest() succeeds (has an rc of 0) as long as
+         // it succeeded in running all the tests, even if some of those
+         // tests failed.  That is, this will succeed as long as there
+         // are no lambdatest framework errors; it's up to use to look
+         // for actual smoketest-code errors in analyzeResults(), below.
+         runLambdaTest();
+      }
+
+      stage("Analyzing results") {
+         analyzeResults();
       }
    }
 }


### PR DESCRIPTION
## Summary:
When running tests -- in this case smoketests -- there are two types
of failures.  The one you normally see is that a test fails, because
we wrote buggy code.  But it's also possible for the test framework
itself to fail: e.g. runlint.py fails to even run due to an import
error.

When running smoketests, we don't want the first type of failure --
actual failures to the smoketests -- to stop the deploy: we just want
to report them and let the deployer decide what to do.  But we do want
to have that second kind of failure stop the deploy, because it means
we don't even know what the smoketest results are!

This PR makes that change.  It depends on the fact that lambdatest
itself distinguishes between these two types of errors, and always
returns rc 0 on successful completion, even if there were the first
type of failure.  It only returns rc 1 for framework errors.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1708023939371849

## Test plan:
Fingers crossed.