### PR TITLE
Turn off caniuse weekly upgrade, for now.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -285,26 +285,28 @@ clean_package_files() {
     jenkins-jobs/safe_git.sh commit_and_push webapp -a -m "Automatic cleanup of language package files"
 }
 
-
-update_caniuse() {
-    # The nodejs "caniuse" library starts complaining if it's more
-    # than a few months out of date.  To avoid that, let's auto-update
-    # it every week!  I follow the instructions at
-    #    https://github.com/facebook/create-react-app/issues/6708#issuecomment-488392836
-    (
-        cd webapp
-        for d in `git grep -l caniuse-lite "*yarn.lock" | xargs -n1 dirname`; do
-            (
-                cd "$d"
-                # This deletes everything from the first "caniuse-lite" line
-                # to the following blank line, from yarn.lock.
-                sed -i '/^caniuse-lite@/,/^$/d' yarn.lock
-                yarn upgrade caniuse-lite browserlist
-            )
-        done
-    )
-    jenkins-jobs/safe_git.sh commit_and_push webapp -m "Automatic update of caniuse, via $0" '*/yarn.lock'
-}
+# NOTE(john, 2024-02-29): Turned off for now, while the Node 20 upgrade is going on.
+# This should be turned back on once the render-gateway and queryplanner services have
+# been successfully upgraded to Node 20.
+#update_caniuse() {
+#    # The nodejs "caniuse" library starts complaining if it's more
+#    # than a few months out of date.  To avoid that, let's auto-update
+#    # it every week!  I follow the instructions at
+#    #    https://github.com/facebook/create-react-app/issues/6708#issuecomment-488392836
+#    (
+#        cd webapp
+#        for d in `git grep -l caniuse-lite "*yarn.lock" | xargs -n1 dirname`; do
+#            (
+#                cd "$d"
+#                # This deletes everything from the first "caniuse-lite" line
+#                # to the following blank line, from yarn.lock.
+#                sed -i '/^caniuse-lite@/,/^$/d' yarn.lock
+#                yarn upgrade caniuse-lite browserlist
+#            )
+#        done
+#    )
+#    jenkins-jobs/safe_git.sh commit_and_push webapp -m "Automatic update of caniuse, via $0" '*/yarn.lock'
+#}
 
 
 # weekly-maintenance.sh calls this script with exactly one arg, the job


### PR DESCRIPTION
## Summary:
This is going to run and that will cause the queryplanner and render-gateway services to attempt to deploy. However, the GCP node16 runtime is deprecated and those services can no longer be deployed. So we need to turn this off until we can successfully deploy this services again, hopefully next week.

Issue: FEI-5536

## Test plan:
The weekly maintenance job should run without errors, I hope!