### PR TITLE
[🔥AUDIT🔥] Allow should_deploy.py to access slack when *deploying* to webapp.

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -400,15 +400,21 @@ def mergeFromMasterAndInitializeGlobals() {
 
             // TODO(benkraft): Extract the resolution of services into a util
             if (params.SERVICES == "auto") {
-               try {
-                  SERVICES = exec.outputOf(["deploy/should_deploy.py"]).split("\n");
-               } catch(e) {
-                  notify.fail("Automatic detection of what to deploy failed. " +
-                              "You can likely work around this by setting " +
-                              "SERVICES on your deploy; see " +
-                              "${env.BUILD_URL}rebuild for documentation, and " +
-                              "`sun: help flags` for how to set it.  If you " +
-                              "aren't sure, ask dev-support for help!");
+               // Slack is temporarily needed while should_deploy is doing
+               // side-by-side testing of the go_code_analysis.go.
+               // TODO(csilvers): remove this once should_deploy.py does
+               //                 not directly import alertlib anymore.
+               withSecrets.slackAlertlibOnly() {
+                  try {
+                     SERVICES = exec.outputOf(["deploy/should_deploy.py"]).split("\n");
+                  } catch(e) {
+                     notify.fail("Automatic detection of what to deploy failed. " +
+                                 "You can likely work around this by setting " +
+                                 "SERVICES on your deploy; see " +
+                                 "${env.BUILD_URL}rebuild for documentation, and " +
+                                 "`sun: help flags` for how to set it.  If you " +
+                                 "aren't sure, ask dev-support for help!");
+                  }
                }
             } else {
                SERVICES = params.SERVICES.split(",");


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Slack is temporarily needed while should_deploy is doing side-by-side
testing of the go_code_analysis.go.

I only do this in deploy-webapp.groovy, though should_deploy.py is
also called in build_webapp.groovy, so we only get notified once per
deploy, not lots of times (as a deploy moves up the queue).  This not
only avoids spam, it makes it easier to figure out which deploy a
slack message corresponds to, since only one deploy-webapp job can be
running at a time.  Since both jobs give the same output, this is safe
to do.

Issue: none

## Test plan:
groovy jobs/deploy-webapp.groovy