### PR TITLE
Removed debug slack message when deploys get stuck in jenkins

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -561,29 +561,12 @@ def _maybeAbortJob(oldBuildResult, newBuildResult, reason) {
    // work like making an HTTP request. If that's the case we are going
    // to cause the job to abort from here to prevent new deploy-webapp
    // jobs from getting stuck.
-   if (oldBuildResult != newBuildResult) {
-      // Because this is a theory that build are getting stuck because the
-      // signal to abort the current thread while we are in an uninterruptible
-      // cycle, we are not 100% sure what the correct things to check are
-      // to make an exact desicion. So we are going to log a message to slack
-      // to keep track of these cases.
-      _simpleSlackAlert(
-         "#infrastructure-deploys",
-         """Deploy aborted but thread is still running. We most likely have a 
-job that is stuck. ${reason}. prev state ${oldBuildResult}. current state 
-${newBuildResult}. ${env.BUILD_URL}. 
-See https://khanacademy.atlassian.net/wiki/spaces/INFRA/pages/2470543393/Stuck+jenkins+deploy-webapp+builds 
-for details to get information about stuck builds. cc @deploy-support""",
-         "error",
-      )
-
-      if (newBuildResult == "ABORTED") {
-         // Jenkins would throw a hudson.AbortException.  But to make
-         // things more clear that the job is aborting itself we will
-         // throw a different exception.  This exception will (should)
-         // be handle by the caller to ensure we clean things up.
-         throw new AbortDeployJob("Deploy was aborted. " + reason)
-      }
+   if (oldBuildResult != newBuildResult && newBuildResult == "ABORTED") {
+      // Jenkins would throw a hudson.AbortException.  But to make
+      // things more clear that the job is aborting itself we will
+      // throw a different exception.  This exception will (should)
+      // be handle by the caller to ensure we clean things up.
+      throw new AbortDeployJob("Deploy was aborted. " + reason)
    }
 }
 

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -272,21 +272,6 @@ def _alert(def slackArgs, def interpolationArgs) {
    }
 }
 
-// TODO(miguel): remove once we are done monitoring hanging deploys.
-def _simpleSlackAlert(def channel, def msg, def severity) {
-   args = ["jenkins-jobs/alertlib/alert.py",
-           "--slack=${channel}",
-           "--chat-sender=Mr Anderson",
-           "--icon-emoji=:crying-nickcage:",
-           "--slack-simple-message",
-           "--severity=${severity}",
-          ];
-   withSecrets.slackAlertlibOnly() {     // to talk to slack
-      echo("sending slack message")
-      sh("echo ${exec.shellEscape(msg)} | ${exec.shellEscapeList(args)}");
-   }
-}
-
 // This method filters a common 'DEPLOYER_USERNAME' into a series of comma
 // seperated slack user id's for the purpose of passing into alert.py's
 // '--slack' argument. For Example:


### PR DESCRIPTION
## Summary:
We had a nasty issue sometime ago in this PR https://github.com/Khan/jenkins-jobs/issues/181.  I have since been able to confirm that the logic is correctly aborting the jobs so I am removing the messages we are sending to slack about stuck jobs.

Issue: https://khanacademy.slack.com/archives/C06385ANLAC/p1712855669448049

## Test plan:
deploy and never see the message again :)