### PR TITLE
Don't have a gc failure be a job failure.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -102,7 +102,14 @@ gc_all_repos() {
         echo "GC-ing in $dir"
         cd "$dir"
 
-        git gc
+        # Sometimes we get an error like this:
+        #   error: Could not read 1f64cbb3aab35f38a0ba7bf53ea29ae399821dd3
+        #   fatal: Failed to traverse parents of commit d2125172e642444012fc1199df32302195d98eec
+        #   fatal: failed to run repack
+        # I have no idea why -- running the gc manually works fine --
+        # but it's not a big deal if we can't gc everything all the
+        # time, so we just let it be.
+        gc || echo "Failed to GC in $dir, continuing anyway"
         )
     done
 }


### PR DESCRIPTION
## Summary:
Sometimes when gc-ing in a workspace, we get an error like this:
```
error: Could not read 1f64cbb3aab35f38a0ba7bf53ea29ae399821dd3
fatal: Failed to traverse parents of commit d2125172e642444012fc1199df32302195d98eec
fatal: failed to run repack
```

I have no idea why -- running the gc manually works fine -- but it's
not a big deal if we can't gc everything all the time, so we just let
it be.  This should quiet the error messages on the weekly maintenance
job, hopefully.

Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/316/execution/node/239/log/

## Test plan:
Fingers crossed