### PR TITLE
Clean the reflog before pulling or gc-ing.

### DIFF
--- a/safe_git.sh
+++ b/safe_git.sh
@@ -83,6 +83,10 @@ _alert() {
 
 # Call this from within the repo that you want to do the fetching.
 _fetch() {
+    # We don't need reflogs in jenkins, and they can cause trouble
+    # when gc-ing, so we remove them.  See
+    #    https://feeding.cloud.geek.nz/posts/error-while-running-git-gc/
+    timeout 120m git reflog expire --all --stale-fix
     timeout 120m git fetch --tags --prune --prune-tags --force --progress origin
 }
 

--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -102,6 +102,12 @@ gc_all_repos() {
         echo "GC-ing in $dir"
         cd "$dir"
 
+        # We don't need reflogs in jenkins, and they can cause trouble
+        # when gc-ing, so we remove them.  See
+        #    https://feeding.cloud.geek.nz/posts/error-while-running-git-gc/
+        # (We didn't do this above because /mnt/jenkins/repositories isn't
+        # a "working" github dir, just a source of .pack files.)
+        git reflog expire --all --stale-fix
         git gc
         )
     done


### PR DESCRIPTION
## Summary:
Every so often -- very commonly when running the weekly maintenence gc
scripts, but at other times like `merge-branches` as well -- we see an
error like:
> warning: reflog of 'HEAD' references pruned commits

@Miguelcastillo did some sleuthing and found the fix, which I put
here.  Since every `pull` can cause a `gc`, I just clean the reflog
before every pull; we don't need the reflog in Jenkins, since it's
really a tool for manual git work and Jenkins is fully automated.

Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/316/execution/node/239/log/

## Test plan:
I ran the new `git reflog` command manually on jenkins in
~jenkins/jobs/misc/jobs/webapp-maintenance/workspace/webapp,
and it ran ok.