### PR TITLE
Use official update package/script for browserslist package update

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -296,10 +296,8 @@ update_caniuse() {
         for d in `git grep -l caniuse-lite "*yarn.lock" | xargs -n1 dirname`; do
             (
                 cd "$d"
-                # This deletes everything from the first "caniuse-lite" line
-                # to the following blank line, from yarn.lock.
-                sed -i '/^caniuse-lite@/,/^$/d' yarn.lock
-                yarn upgrade caniuse-lite browserslist
+                # Use the official tool to update the browserslist and caniuse-lite packages.
+                npx update-browserslist-db@latest
             )
         done
     )

--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -176,7 +176,7 @@ clean_graphql_gateway_schemas() {
 }
 
 # TODO(FEI-4154): Fix this logic to be more robust.
-# We're disabling clean_ka_static() for the time 
+# We're disabling clean_ka_static() for the time
 # being to avoid deleting files we need by accident.
 # clean_ka_static() {
 #     # First we ask Fastly for the list of live static versions.
@@ -299,7 +299,7 @@ update_caniuse() {
                 # This deletes everything from the first "caniuse-lite" line
                 # to the following blank line, from yarn.lock.
                 sed -i '/^caniuse-lite@/,/^$/d' yarn.lock
-                yarn upgrade caniuse-lite browserlist
+                yarn upgrade caniuse-lite browserslist
             )
         done
     )


### PR DESCRIPTION
## Summary:

EDIT: I've updated this PR to use the official script (`update-browserslist-db`) instead of the manual `sed` + `yarn` system.

https://github.com/browserslist/update-db

~Our `weekly-maintenance-jobs.sh` script updates the browserslist and caniuse-lite packages. In the `yarn` invocation, we're using the wrong package name. Thankfully, there is a typo package (`browserlist`) that points to the right package. But long term we should be using the correct name (`browserslist` (note the `s` suffix)).~

~See: https://www.npmjs.com/package/browserlist which reads:~

~> Package to help in popular typo: browserlist instead of browserslist~

<img width="720" alt="image" src="https://github.com/user-attachments/assets/d3f6ea84-13e1-4211-b79c-1d414fb3d112">

Issue: "none"

## Test plan:

:fingerscrossed: