### PR TITLE
[🔥AUDIT🔥] Do not do reflog cleaning all the time, only in the weekly maintenance.

### DIFF
--- a/safe_git.sh
+++ b/safe_git.sh
@@ -83,10 +83,6 @@ _alert() {
 
 # Call this from within the repo that you want to do the fetching.
 _fetch() {
-    # We don't need reflogs in jenkins, and they can cause trouble
-    # when gc-ing, so we remove them.  See
-    #    https://feeding.cloud.geek.nz/posts/error-while-running-git-gc/
-    timeout 120m git reflog expire --all --stale-fix
     timeout 120m git fetch --tags --prune --prune-tags --force --progress origin
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It's slow, and we believe it's causing errors (perhaps when the reflog
and gc coincide).

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1721248190898759

## Test plan:
Fingers crossed

Subscribers: @somewhatabstract