### PR TITLE
Run devserver's upload-images under ssh-agent.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -65,7 +65,7 @@ def uploadService(service) {
       // but unpredictably) fails with:
       // ERROR: failed to receive status: rpc error: code = Unavailable desc = error reading from server: EOF
       retry(5) {
-         exec(["dev/server/upload-images.sh", "--no-tags", service]);
+         exec(["ssh-agent", "sh", "-c", "ssh-add; dev/server/upload-images.sh --no-tags " + service]);
       }
    }
 }


### PR DESCRIPTION
## Summary:
In https://github.com/Khan/webapp/pull/24656, I change
upload-images.sh to use ssh-agent to register the ssh key.  This
actually runs ssh-agent on jenkins so we can make use of that.

Even before #24656 is landed, this is safe to do; it's just a noop.
Thus I'll do it first, then deploy the change in webapp.

Issue: https://khanacademy.slack.com/archives/C065UP1CC9M/p1723674135047609?thread_ts=1723667038.669609&cid=C065UP1CC9M

## Test plan:
I ran this new script manually on jenkins:
https://jenkins.khanacademy.org/job/misc/job/update-devserver-static-images/395/console

Subscribers: @Khan/infra-platform