### PR TITLE
[🔥AUDIT🔥] Run more ownership_data tests when updating ownership data.

### DIFF
--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -56,7 +56,7 @@ def runScript() {
       sh("dev/tools/update_ownership_data.py");
 
       // Check we didn't break anything.
-      sh("tools/runtests.sh dev/consistency_tests/ownership_test.py");
+      sh("tools/runtests.sh dev/consistency_tests/ownership_test.py dev/tools/update_ownership_data_test.py");
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
When we update the ownership data in our nightly deploy, we run some
tests to make sure that the new ownership data doesn't break anything.
It turns out that some potential problems are tested in a _different_
ownership test, so we need to run that one too.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1724751059899299

## Test plan:
I ran the new command manually on jenkins

Subscribers: @jeresig