### PR TITLE
Refactor the jenkins jobs so they don't run `clean` after building deps.

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -381,8 +381,6 @@ def mergeFromMaster() {
 def initializeGlobals() {
    withTimeout('1h') {    // should_deploy builds files, which can take forever
       dir("webapp") {
-         clean(params.CLEAN);
-
          // Let's do a sanity check.
          def headSHA1 = exec.outputOf(["git", "rev-parse", "HEAD"]);
          if (params.GIT_REVISION != headSHA1) {


### PR DESCRIPTION
## Summary:
Several of our jobs run `virtualenv.withPython3` at a very high level
(in main).  And then call a function that calls `clean()`.
Unfortunately, that's not safe: `withPython3` builds python deps that
`clean()` can nuke.  Luckily, this doesn't happen by default: you have
to run with `CLEAN=all`.  But it's still a problem.

This PR refactors the jobs so they always run `withPython3` after
`clean`, rather than before.  A better fix would be to only run
`withPython3` in the places we're actually running python3 code, not
at this high level in `main()`, but that's a more significant
refactor, for another day.

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1724860397897649

## Test plan:
Mostly fingers crossed -- I'll try the jobs on Jenkins.  But I did run:
```
groovy jobs/build-webapp.groovy
groovy jobs/deploy-webapp.groovy
groovy jobs/deploy-znd.groovy
```
which showed no syntax errors.

Subscribers: @somewhatabstract