### PR TITLE
Do not allow pushing to webapp's master from jenkins jobs.

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -48,6 +48,11 @@ the updated data-file to it.""",
 
 
 def _setupWebapp() {
+   // We do not allow pushing directly to master.
+   if (params.GIT_BRANCH == "master") {
+      notify.fail("You may not push directly to master.  Try `automated-commits` instead.")
+   }
+
    // We do our work in the automated-commits branch (first pulling in master).
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", params.GIT_BRANCH);
    if (params.MERGE_MASTER) {

--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -35,6 +35,11 @@ the updated data-file to it.""",
 
 
 def _setupWebapp() {
+   // We do not allow pushing directly to master.
+   if (params.GIT_BRANCH == "master") {
+      notify.fail("You may not push directly to master.  Try `automated-commits` instead.")
+   }
+
    // We do our work in the automated-commits branch (first pulling in master).
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", params.GIT_BRANCH);
    kaGit.safeMergeFromMaster("webapp", params.GIT_BRANCH);


### PR DESCRIPTION
## Summary:
That is what the `automated-commits` branch is for!  So let people
know that in the two jobs that push things to a user-specified branch.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1726518628937639

## Test plan:
groovy jobs/update-devserver-static-images.groovy
groovy jobs/update-ownership-data.groovy

Subscribers: @kevinb-khan