### PR TITLE
Deploy to fastly-staging as part of the deploy process.

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -478,6 +478,20 @@ def _manualSmokeTestCheck(job){
 }
 
 
+def deployFastlyStaging() {
+   withTimeout('10m') {
+      withSecrets.slackAndStackdriverAlertlibOnly() {
+         exec(["make", "-C", "webapp/services/fastly-khanacademy-compute",
+               "deploy-staging",
+               "ALREADY_RAN_TESTS=1",
+               "DEPLOY_VERSION=${NEW_VERSION}"]);
+         exec(["make", "-C", "webapp/services/fastly-khanacademy-compute",
+               "set-default-staging",
+               "DEPLOY_VERSION=${NEW_VERSION}"]);
+      }
+   }
+}
+
 def verifySmokeTestResults(jobName, buildmasterFailures=0) {
    withTimeout('60m') {
       def status;
@@ -936,7 +950,26 @@ onMaster('4h') {
       }
 
       try {
+         stage("Deploy fastly-staging if needed") {
+            // We only ever do this in this job, which applies to the
+            // first deploy in the queue exclusively (rather than in
+            // build-webapp.groovy, which happens in parallel to
+            // every(ish) deploy in the queue), since we only have one
+            // staging service in fastly.
+            if ('fastly-khanacademy-compute' in SERVICES) {
+               deployFastlyStaging();
+            }
+         }
          stage("Await first smoke test") {
+            // NOTE: the first-smoke-test run has been going on for a
+            // while, and until now it will have hit old code in the
+            // fastly staging-service, not the new code that we just
+            // deployed above.  This is unavoidable because we can run
+            // multiple first-smoke-test runs at the same time (one
+            // for every deploy in the deploy queue), but we only have
+            // one "staging" fastly service, which we reserve for the
+            // deploy at the front of the deploy queue.
+            // TODO(csilvers): figure out a way to handle this better.
             if (SERVICES) {
                verifySmokeTestResults('first-smoke-test');
             }


### PR DESCRIPTION
## Summary:
The idea is that if you are deploying fastly as part of your deploy,
we want the pre-set-default url
(`https://prod-2409<etc>.khanacademy.org`), to execute the new fastly
code.  The way we do this is to deploy the new fastly code to a
separate "staging" fastly service, and then route all requests to
prod-etc.ka.org to that staging fastly service instead of the regular
prod fastly service.

The details of how we do that routing are beyond the scope of this PR,
but this PR _does_ do the important step of making sure that the
"staging" fastly service has the code for this deploy in it!  And it
makes sure that happens before we do the "set default" prompt, so that
any manual testing that is done gets the new fastly.

Sadly, the first-smoke-test run does _not_ hit the new fastly, it
still hits the old one.  This is unavoidable because we can run
multiple fisrt-smoke-test runs at the same time (one for every deploy
in the deploy queue), but we only have one "staging" fastly service,
which we reserve for the deploy at the front of the deploy queue.
I've added a NOTE about that, we will have to try to figure out some
way to handle this, later.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10385

## Test plan:
groovy jobs/deploy-webapp.groovy