### PR TITLE
Do not try to deploy to fastly-staging in deploy-webapp.groovy.

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -478,20 +478,6 @@ def _manualSmokeTestCheck(job){
 }
 
 
-def deployFastlyStaging() {
-   withTimeout('10m') {
-      withSecrets.slackAndStackdriverAlertlibOnly() {
-         exec(["make", "-C", "webapp/services/fastly-khanacademy-compute",
-               "deploy-staging",
-               "ALREADY_RAN_TESTS=1",
-               "DEPLOY_VERSION=${NEW_VERSION}"]);
-         exec(["make", "-C", "webapp/services/fastly-khanacademy-compute",
-               "set-default-staging",
-               "DEPLOY_VERSION=${NEW_VERSION}"]);
-      }
-   }
-}
-
 def verifySmokeTestResults(jobName, buildmasterFailures=0) {
    withTimeout('60m') {
       def status;
@@ -950,16 +936,6 @@ onMaster('4h') {
       }
 
       try {
-         stage("Deploy fastly-staging if needed") {
-            // We only ever do this in this job, which applies to the
-            // first deploy in the queue exclusively (rather than in
-            // build-webapp.groovy, which happens in parallel to
-            // every(ish) deploy in the queue), since we only have one
-            // staging service in fastly.
-            if ('fastly-khanacademy-compute' in SERVICES) {
-               deployFastlyStaging();
-            }
-         }
          stage("Await first smoke test") {
             // NOTE: the first-smoke-test run has been going on for a
             // while, and until now it will have hit old code in the


### PR DESCRIPTION
## Summary:
That's too late!  This script doesn't get run until _after_ you say
`sun: set default`.  The whole point of the staging environment is to
be available _before_ you say `sun: set default`, when you're doing
the manual testing.

Sadly, doing this in build-webapp.groovy isn't right either, since
many of those get run in parallel, and there's only one fastly-staging
service.  If we really wanted to cram this logic in, we'd have to do
it in buildmaster, before showing the "time to set default" message to
the user.  But that's a really awkward place to put it.

We'll have to think more about what the right thing to do here.  The
whole fastly-staging thing isn't as useful as it might be, since it
doesn't work for first smoke tests, znd's, or any number of other
things we might want it to.  Perhaps fixing that problem will make it
obvious where this logic should move to (probably
build-webapp.groovy).

Issue: none

## Test plan:
Noticing https://jenkins.khanacademy.org/job/deploy/job/deploy-webapp/20552/console