### PR TITLE
[🔥AUDIT🔥] Do more pruning of bad references when gc-ing.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -107,6 +107,8 @@ gc_all_repos() {
         #    https://feeding.cloud.geek.nz/posts/error-while-running-git-gc/
         # (We didn't do this above because /mnt/jenkins/repositories isn't
         # a "working" github dir, just a source of .pack files.)
+        # We also get rid of stale branches, which can also cause gc issues.
+        git remote prune origin
         git reflog expire --all --stale-fix
         git gc
         )


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We got into an error when gc-ing this week:
```
+ echo 'GC-ing in /var/lib/jenkins/jobs/deploy/jobs/merge-branches/workspace@15/webapp'
GC-ing in /var/lib/jenkins/jobs/deploy/jobs/merge-branches/workspace@15/webapp
+ cd /var/lib/jenkins/jobs/deploy/jobs/merge-branches/workspace@15/webapp
+ git reflog expire --all --stale-fix
fatal: unable to parse object: refs/remotes/origin/AX-194
```

Perhaps because AX-194 got deleted, but this branch didn't get the
memo.  In any case, `git remote prune` is meant to handle exactly this
situation.

Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/329/execution/node/382/log/

## Test plan:
I successfully ran this command manually in
/var/lib/jenkins/jobs/deploy/jobs/merge-branches/workspace@15/webapp