### PR TITLE
Ensure buildmaster code is up to date before deploys

### DIFF
--- a/jobs/deploy-buildmaster.groovy
+++ b/jobs/deploy-buildmaster.groovy
@@ -35,7 +35,6 @@ def buildAndDeploy() {
 
     dir("buildmaster2") {
       withEnv([
-          "CLOUDSDK_CORE_ACCOUNT=buildmaster-deploy@${params.GCLOUD_PROJECT}.iam.gserviceaccount.com",
           "GCLOUD_PROJECT=${params.GCLOUD_PROJECT}"
       ]) {
         try {


### PR DESCRIPTION
## Summary:
`quickClone` just runs a clone. If the repo is already on disk, the code isn't updated. Instead use the safeSyncToOrigin function. Also change the alert channel name for the sake of reducing noise during the hackathon.

Issue: XXX-XXXX

## Test plan: