### PR TITLE
Add the concept of a "failure channel" and use it for emergency-rollback.

### DIFF
--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -144,6 +144,7 @@ def doRollback() {
 
 onMaster('1h') {
    notify([slack: [channel: '#1s-and-0s-deploys',
+                   failureChannel: '#infrastructure-platform',
                    sender: 'Mr Monkey',
                    emoji: ':monkey_face:',
                    when: ['BUILD START', 'SUCCESS',

--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -91,6 +91,7 @@ def publishResults() {
 
 onMaster('10h') {
    notify([slack: [channel: params.SLACK_CHANNEL,
+                   failureChannel: "#infrastructure-platform",
                    sender: 'Devserver Duck',
                    emoji: ':duck:',
                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {

--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -83,6 +83,7 @@ def publishResults() {
 
 onMaster('2h') {
    notify([slack: [channel: params.SLACK_CHANNEL,
+                   failureChannel: "#infrastructure-platform",
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -138,6 +138,8 @@ def _sendToAlertlib(subject, severity, body, extraFlags) {
 // when (required): under what circumstances to send to slack; a list.
 //    Possible values are SUCCESS, FAILURE, UNSTABLE, or BACK TO NORMAL.
 //    (Used in call(), below.)
+// failureChannel: send to this channel, in addition to `channel`, when
+//    the jobs fails (`when` is FAILURE or UNSTABLE).
 // sender: the name to use for the bot message (e.g. "Jenny Jenkins")
 // emoji: the emoji to use for the bot (e.g. ":crocodile:")
 // emojiOnFailure: the emoji to use for the bot when sending a message that
@@ -186,7 +188,12 @@ def sendToSlack(slackOptions, status, extraText='') {
             extra_text: extraText,
          ]);
       if (_failed(status)) {
-         // Also send all failures to deploy-support-log
+         // Also send to failureChannel, if it's set.
+         if (slackOptions.failureChannel) {
+             def failureChannelFlags = ["--slack=${slackOptions.failureChannel}"];
+             _sendToAlertlib(subject, severity, body, extraFlags + failureChannelFlags);
+         }
+         // Also always send all failures to deploy-support-log.
          def logChannelFlags = ["--slack=CB00L3VFZ"];   // deploy-support-log
          _sendToAlertlib(subject, severity, body, extraFlags + logChannelFlags);
       }


### PR DESCRIPTION
## Summary:
Sometimes, we send slack messages to a busy or unattended channel,
because most of the time the information isn't that interesting.  But
sometimes it's only not interesting when it works as intended --
e.g. the nightly dev-images update.  But if it fails, we want to know
about it.

This PR introduces the concept of a "failure channel", which if
specified means that when a job fails, we send the slack message
twice: once to the normal channel, but a second time to the failure
channel.  The idea being the failure channel is looked at more
closely.

I use this concept for a few jobs I think would benefit from it:
emergency-rollback -- which has been broken since March and we never
really noticed! -- and the update scripts.

Issue: none

## Test plan:
Fingers crossed.  I did run
```
groovy vars/notify.groovy
groovy jobs/emergency-rollback.groovy
[and likewise for the other changed files]
```