### PR TITLE
Add choice param for which buildmaster service or job to deploy

### DIFF
--- a/jobs/deploy-buildmaster.groovy
+++ b/jobs/deploy-buildmaster.groovy
@@ -71,7 +71,7 @@ def buildAndDeploy() {
 }
 
 onMaster('90m') {
-  notify([slack: [channel: '#1s-and-0s-deploys',
+  notify([slack: [channel: '#infrastructure-deploys',
                   sender : 'Mr Meta Monkey',  // we may be deploying Mr. Monkey himself!
                   emoji  : ':monkey_face:',
                   when   : ['BUILD START', 'SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {


### PR DESCRIPTION
## Summary:
Adds a param to select which job should be deployed. Note, before merging, update the notify channel to 1s-and-0s
Issue: INFRA-10443

## Test plan:
Run as a replay in jenkins