### PR TITLE
Remove course-editing from build and deploy jobs.

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -48,8 +48,6 @@ specify "users,static" to force a full deploy to the users service and GCS.</p>
 <p>Here are some services:</p>
 <ul>
   <li> <b>static</b>: Upload static (e.g. js) files to GCS. </li>
-  <li> <b>kotlin-routes</b>: webapp's services/kotlin-routes/. </li>
-  <li> <b>course-editing</b>: webapp's services/course-editing/. </li>
   <li> <b>donations</b>: webapp's services/donations/. </li>
 </ul> """,
     "auto"
@@ -206,21 +204,6 @@ def deployToService(service) {
    }
 }
 
-
-// This should be called from within a node().
-// HACK: This is a workaround to manage a bug in our current deploy system,
-// where running gradlew in two services in parallel causes a conflict in
-// the cache dir (See INFRA-3594 for full details). Here we're careful to
-// build kotlin services in series. Once this bug is resolved, we can remove
-// this, and let kotlin services default to the shared deployToService again.
-def deployToKotlinServices() {
-   for (service in SERVICES) {
-      if (service in ['course-editing', 'kotlin-routes']) {
-         deployToService(service);
-      }
-   }
-}
-
 // This should be called from within a node().
 def deployIndexYaml() {
    if (!("index_yaml" in SERVICES)) {
@@ -366,7 +349,7 @@ def deploy() {
                            "You can likely work around this by setting " +
                            "SERVICES on your deploy by a comma-separated " +
                            "list of services. For instance: " +
-                           "'static,donations,kotlin-routes'");
+                           "'static,donations'");
             }
          } else {
             SERVICES = params.SERVICES.split(",").collect { it.trim() };
@@ -388,12 +371,6 @@ def deploy() {
          switch (service) {
             case "static":
                jobs["deploy-to-gcs"] = { deployToGCS(); };
-               break;
-
-            // These two services are a bit more complex and are handled
-            // specially.
-            case ( "kotlin-routes" || "course-editing" ):
-               jobs["deploy-to-kotlin-services"] = { deployToKotlinServices(); };
                break;
 
             case "index_yaml":

--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -45,14 +45,14 @@ is primarily useful for making sure the job has a recent checkout of webapp.
    "ROLLBACK_TO",
    """The version to rollback to. If not provided, we will default to the
    most recent good version on app engine. This is a full version tag name,
-   e.g. gae-181217-1330-b18f83d38a3d-kotlin-routes-181217-0832-789e0227e0ba""",
+   e.g. gae-181217-1330-b18f83d38a3d-content-editing-181217-0832-789e0227e0ba""",
    ""
 
 ).addStringParam(
    "BAD_VERSION",
    """The version to rollback from and mark `-bad` in git. If not provided, we
    look for the current live version. This is also a full version tag name,
-   e.g. gae-181217-2111-5f05dc51cf56-kotlin-routes-181217-0832-789e0227e0ba""",
+   e.g. gae-181217-2111-5f05dc51cf56-content-editing-181217-0832-789e0227e0ba""",
    ""
 // NOTE(benkraft): This runs in a cron job started from the buildmaster,
 // instead of a jenkins cron job, because jenkins cron jobs can't pass


### PR DESCRIPTION
## Summary:
Also remove kotlin-routes from build and deploy jobs.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9851

## Test plan:

1. After merge, monitor deploy jobs from #1s-and-0s-deploys for errors.
2. Trigger a deploy ZND job and monitor for errors.