### PR TITLE
Clean up the buildmaster tags every week.

### DIFF
--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -231,7 +231,7 @@ def mergeBranches(gitRevisions, tagName) {
       // We need to at least tag the commit, otherwise github may prune it.
       // (We can skip this step if something already points to the commit; in
       // fact we want to to avoid Phabricator paying attention to this commit.)
-      // TODO(benkraft): Prune these tags eventually.
+      // These tags ar pruned weekly in weekly-maintenance.sh.
       if (exec.outputOf(["git", "tag", "--points-at", "HEAD"]) == "" &&
           exec.outputOf(["git", "branch", "-r", "--points-at", "HEAD"]) == "") {
          exec(["git", "tag", tagName, "HEAD"]);

--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -79,6 +79,26 @@ clean_invalid_branches() {
     done
 }
 
+# The merge-branches jenkins job creates a git-tag to make sure the
+# merged code isn't gc-ed by Jenkins.  It only needs to survive for
+# the length of a deploy: maybe an hour or so.  We keep these tags
+# around a week.
+prune_buildmaster_tags() {
+    (
+        cd webapp
+        # We delete tags 100 at a time to avoid overwhelming github.
+        git tag -l 'buildmaster-*' \
+            | grep -v \
+                   -e buildmaster-'[0-9]*'-$(date -d "today" +%Y%m%d) \
+                   -e buildmaster-'[0-9]*'-$(date -d "today -1 day" +%Y%m%d) \
+                   -e buildmaster-'[0-9]*'-$(date -d "today -2 days" +%Y%m%d) \
+                   -e buildmaster-'[0-9]*'-$(date -d "today -3 days" +%Y%m%d) \
+                   -e buildmaster-'[0-9]*'-$(date -d "today -4 days" +%Y%m%d) \
+                   -e buildmaster-'[0-9]*'-$(date -d "today -5 days" +%Y%m%d) \
+                   -e buildmaster-'[0-9]*'-$(date -d "today -6 days" +%Y%m%d) \
+            | xargs -n 100 git push --no-verify --delete origin
+    )
+}
 
 # Explicitly run `gc` on every workspace.  This causes us to repack
 # all our objects using the "alternates" directory, which saves a


### PR DESCRIPTION
## Summary:
We have 55,000 of these!  They were meant to be short-lived (like a
few minutes long) tags, but we never wrote the code to prune them.
Let's do that now.

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1731094743406639

## Test plan:
Fingers crossed.  I ran the grep part manually and saw it exclude tags
from the last 7 days.