### PR TITLE
Add option for buildmaster db migration deploys

### DIFF
--- a/jobs/deploy-buildmaster.groovy
+++ b/jobs/deploy-buildmaster.groovy
@@ -25,7 +25,7 @@ new Setup(steps
 
 ).addChoiceParam(
     "SERVICE_OR_JOB",
-    """<b>REQUIRED</b>. The service or job to deploy. Note that "all" will deploy everything other than migrate-db""",
+    """<b>REQUIRED</b>. The service or job to deploy. Note that "all" will deploy everything other than migrate-db and generate-db-migration-scripts""",
     ["all", "buildmaster", "reaper-job", "trigger-reminders-job", "warm-rollback-job", "migrate-db", "generate-db-migration-scripts"]
 
 ).apply();


### PR DESCRIPTION
## Summary:
There are two make rules, one that generates migration scripts and one that deploys and executes the buildmaster db migration job. See https://github.com/Khan/buildmaster2/pull/193

Issue: INFRA-10476

## Test plan:
Run the job and ensure the db miration was deployed and executed