### PR TITLE
[🔥AUDIT🔥] Pass FASTLY_COMPUTE_ENVIRONMENT_COOKIE to lambdatest

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -181,19 +181,21 @@ def runLambdaTest() {
    // in the LambdaTest build.
    def e2eEnv = E2E_URL == "https://www.khanacademy.org" ? "prod" : "preprod";
 
-   // Determine which Fastly service to route requests to.
-   def fastlyServiceID = "" // Default to PROD [VCL].
+   // Determine the value of the `ka-fastly-compute-environment` cookie to set
+   // when running the E2E tests.  These cookie values come from:
+   // https://khanacademy.atlassian.net/wiki/spaces/INFRA/pages/3382050914/VCL+to+Fastly+Compute+routing
+   def fastlyComputeEnvironmentCookie = "" // Default to PROD [VCL].
    if (params.FASTLY_SERVICE == "PROD [COMPUTE]") {
-      fastlyServiceID = "XVn2m1dzuB3ebdNAY6UsY1"
+      fastlyComputeEnvironmentCookie = "XVn2m1dzuB3ebdNAY6UsY1"
    } else if (params.FASTLY_SERVICE == "STAGING [COMPUTE]") {
-      fastlyServiceID = "luUUdGK4AEAIz1vqRyQ180"
+      fastlyComputeEnvironmentCookie = "luUUdGK4AEAIz1vqRyQ180"
    } else if (params.FASTLY_SERVICE == "TEST [COMPUTE]") {
-      fastlyServiceID = "uz47U4v9JmAHQhlAhnsHr4"
+      fastlyComputeEnvironmentCookie = "uz47U4v9JmAHQhlAhnsHr4"
    }
 
    def runLambdaTestArgs = ["yarn",
                             "lambdatest",
-                            "--envs \"FASTLY_COMPUTE_SERVICE_ID=${fastlyServiceID}\"",
+                            "--envs \"FASTLY_COMPUTE_ENVIRONMENT_COOKIE=${fastlyComputeEnvironmentCookie}\"",
                             "--cy='--config baseUrl=\"${E2E_URL}\",retries=${params.TEST_RETRIES}'",
                             "--bn='${BUILD_NAME}'",
                             "-p=${params.NUM_WORKER_MACHINES}",


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
@miguelcastillo caught a mistake I made in #250.  I was passing the service ID instead of the cookie value.  This PR fixes that and adds a link to the Confluence page with the cookie values which is our source of truth for these values.

The corresponding webapp changes can be found in https://github.com/Khan/webapp/pull/27243.

Issue: None

## Test plan:
- land
- start a job and stop it (this will force jenkins to update)
- start a new job that runs tests on the `route-e2e-tests-to-compute` branch in webapp and sets the `FASTLY_SERVICE` param to `PROD [Compute]`