### PR TITLE
Get rid of some unused parameters on the deploy-znd job.

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -52,21 +52,6 @@ specify "users,static" to force a full deploy to the users service and GCS.</p>
 </ul> """,
     "auto"
 
-).addBooleanParam(
-    "SKIP_I18N",
-    "If set, do not build translated versions of the webapp content.",
-    false
-
-// TODO(benkraft): Modify this script to think in terms of services,
-// like build-webapp does, if we ever have znds for other services.
-
-).addStringParam(
-    "MODULES",
-    """A comma-separated list of modules to upload to appengine. For a list
-of all modules we support, see <code>webapp/modules_util.py</code>.
-The special value 'all' uploads all modules.""",
-    "default"
-
 ).addChoiceParam(
     "CLEAN",
     """\
@@ -181,7 +166,6 @@ def deployToGCS() {
                "--slack-channel=${params.SLACK_CHANNEL}",
                "--deployer-username=@${_currentUser()}"];
    args += params.SLACK_THREAD ? ["--slack-thread=${params.SLACK_THREAD}"] : [];
-   args += params.SKIP_I18N ? ["--no-i18n"] : [];
    if (!("static" in SERVICES)) {
       args += ["--copy-from=default"];
    }


### PR DESCRIPTION
## Summary:
We used to let people turn off translating all the js at deploy time,
if they only wanted to test language-agnostic functionality. This
made the deploys go quite a bit faster.

But now we no longer translate at deploy-time, but instead at runtime.
So there's no need for this option anymore!

I removed it in webapp in https://github.com/Khan/webapp/pull/27729.
I could have left it as a deprecated param here, but since we can just
tell people not to use `deploy_znd.py` with the `--no-i18n` flag
anymore, there's no need to keep it around, and it's nice to clean it
up.

In fact, I cleaned up another param we don't use anymore, MODULES.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1732547649381639

## Test plan:
Mostly fingers crossed.  I did, however, visit
   https://github.com/search?q=org%3AKhan+deploy-znd&type=code
to verify that deploy_znd.py is the only place where we
programatically trigger this jenkins job.

Subscribers: @Khan/infra-platform