### PR TITLE
Add temporary Cypress Cloud integration

### DIFF
--- a/jobs/e2e-test-cycloud.groovy
+++ b/jobs/e2e-test-cycloud.groovy
@@ -202,7 +202,7 @@ def runE2ETests(workerId) {
 
    // NOTE: We hard-code the values here as it is an experiment that will be
    // removed soon.
-   def runE2ETestsArgs = ["CYPRESS_PROJECT_ID=2c1iwj && CYPRESS_RECORD_KEY=4c530cf3-79e5-44b5-aedb-f6f017f38cb5 && ./dev/cypress/e2e/tools/start-cypress-cloud-run.ts"];
+   def runE2ETestsArgs = ["env", "CYPRESS_PROJECT_ID=2c1iwj", "CYPRESS_RECORD_KEY=4c530cf3-79e5-44b5-aedb-f6f017f38cb5", "./dev/cypress/e2e/tools/start-cypress-cloud-run.ts"];
 
    dir('webapp/services/static') {
       exec(runE2ETestsArgs);

--- a/jobs/e2e-test-cycloud.groovy
+++ b/jobs/e2e-test-cycloud.groovy
@@ -1,0 +1,230 @@
+// Single job for cypress e2e tests.
+//
+// cypress e2e tests are the smoketests run in the webapp/feature/cypress repo,
+// that hit a live website using lambdatest cli.
+@Library("kautils")
+// Classes we use, under jenkins-jobs/src/.
+import org.khanacademy.Setup;
+// Vars we use, under jenkins-jobs/vars/.  This is just for documentation.
+//import vars.exec
+//import vars.notify
+//import vars.withTimeout
+
+new Setup(steps
+
+).allowConcurrentBuilds(
+
+// We do a lot of e2e-test runs, and QA would like to be able to see details
+// for a bit longer.
+).resetNumBuildsToKeep(
+   350,
+
+).addStringParam(
+   "URL",
+   "The url-base to run these tests against.",
+   "https://www.khanacademy.org"
+
+)
+.addChoiceParam(
+   "TEST_TYPE",
+   """IGNORE: This is a dummy parameter that is only here to avoid breaking the
+   communication with buildmaster""",
+   ["all", "deploy", "custom"]
+
+).addStringParam(
+   "TESTS_TO_RUN",
+   """IGNORE: This is a dummy parameter that is only here to avoid breaking the
+   communication with buildmaster""",
+   ""
+
+).addStringParam(
+   "SLACK_CHANNEL",
+   "The slack channel to which to send failure alerts.",
+   "#cypress-logs-next-test"
+
+).addStringParam(
+   "SLACK_THREAD",
+   """The slack thread (must be in SLACK_CHANNEL) to which to send failure
+alerts.  By default we do not send in a thread.  Generally only set by the
+buildmaster, to the 'thread_ts' or 'timestamp' value returned by the Slack
+API.""",
+    ""
+
+).addStringParam(
+   "NUM_WORKER_MACHINES",
+   """How many worker machines to use in LambdaTest. Max available is 30.""",
+   "30"
+
+).addBooleanParam(
+   "USE_FIRSTINQUEUE_WORKERS",
+   """If true, use the jenkins workers that are set aside for the
+currently active deploy.  Obviously, this should only be set if you
+are, indeed, the currently active deploy.  We reserve these machines
+so the currently active deploy never has to wait for smoketest workers
+to spin up.""",
+   false
+
+).addStringParam(
+   "CYPRESS_GIT_REVISION",
+   """A commit-ish to check out.  This only affects the version of the
+E2E test used; it will probably match the tested version's code,
+but it doesn't need to.""",
+   "master"
+
+).addStringParam(
+   "REVISION_DESCRIPTION",
+   """Set by the buildmaster to give a more human-readable description
+of the CYPRESS_GIT_REVISION, especially if it is a commit rather than a branch.
+Defaults to CYPRESS_GIT_REVISION.""",
+   ""
+
+).addStringParam(
+   "BUILDMASTER_DEPLOY_ID",
+   """Set by the buildmaster, can be used by scripts to associate jobs
+that are part of the same deploy.  Write-only; not used by this script.""",
+   ""
+
+).addBooleanParam(
+   "SET_SPLIT_COOKIE",
+   """IGNORE: This is a dummy parameter that is only here to avoid breaking the
+   communication with buildmaster""",
+   false
+
+).addStringParam(
+   "JOB_PRIORITY",
+   """The priority of the job to be run (a lower priority means it is run
+sooner). The Priority Sorter plugin reads this parameter in to reorder jobs
+in the queue accordingly. Should be set to 3 if the job is depended on by
+the currently deploying branch, otherwise 6. Legal values are 1
+through 11. See https://jenkins.khanacademy.org/advanced-build-queue/
+for more information.""",
+   "6"
+
+).addStringParam(
+   "SKIP_TESTS",
+   """IGNORE: This is a dummy parameter that is only here to avoid breaking the
+   communication with buildmaster""",
+   ""
+
+).apply();
+
+
+// We set these to real values first thing below; but we do it within
+// the notify() so if there's an error setting them we notify on slack.
+NUM_WORKER_MACHINES = null;
+// Used to tell whether all the test-workers raised an exception.
+WORKERS_RAISING_EXCEPTIONS = 0;
+public class TestFailed extends Exception {}  // for use with the above
+// Used to make sure we finish our job as soon as all tests are run.
+public class TestsAreDone extends Exception {}
+
+
+// Override the build name by the info that is passed in (from buildmaster).
+REVISION_DESCRIPTION = params.REVISION_DESCRIPTION ?: params.CYPRESS_GIT_REVISION;
+E2E_URL = params.URL[-1] == '/' ? params.URL.substring(0, params.URL.length() - 1): params.URL;
+
+currentBuild.displayName = ("${currentBuild.displayName} " +
+                            "(${REVISION_DESCRIPTION})");
+
+// We use the build name as a unique identifier for user notifications.
+BUILD_NAME = "build e2e-cypress-test #${env.BUILD_NUMBER} (${E2E_URL}: ${params.REVISION_DESCRIPTION})"
+
+// GIT_SHA1 is the sha1 for CYPRESS_GIT_REVISION.
+GIT_SHA1 = null;
+
+// We have a dedicated set of workers for the second smoke test.
+WORKER_TYPE = (params.USE_FIRSTINQUEUE_WORKERS
+               ? 'ka-firstinqueue-ec2' : 'ka-test-ec2');
+
+def initializeGlobals() {
+   NUM_WORKER_MACHINES = params.NUM_WORKER_MACHINES.toInteger();
+}
+
+
+def _setupWebapp() {
+   GIT_SHA1 = kaGit.resolveCommitish("git@github.com:Khan/webapp",
+                                        params.CYPRESS_GIT_REVISION);
+
+   kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", GIT_SHA1);
+
+   dir("webapp/services/static") {
+      sh("yarn install --frozen-lockfile");
+   }
+}
+
+// Run all the test-clients on all the worker machine, in parallel.
+def runAllTestClients() {
+   // We want to swallow any framework exceptions unless *all* the
+   // clients have raised a framework exception.  Our theory is that
+   // if one client dies unexpectedly the others can compensate, but
+   // if they all do, then there's nothing more we can do.
+   def onException = {
+      echo("Worker raised an exception");
+      WORKERS_RAISING_EXCEPTIONS++;
+      if (WORKERS_RAISING_EXCEPTIONS == NUM_WORKER_MACHINES) {
+         echo("All worker machines failed!");
+         throw new TestFailed("All worker machines failed!");
+      }
+   }
+
+   def jobs = [:];
+   for (i = 0; i < NUM_WORKER_MACHINES; i++) {
+      def workerId = i;  // avoid scoping problems
+      jobs["e2e-test-${workerId}"] = {
+         swallowExceptions({
+            onWorker(WORKER_TYPE, '2h') {
+                _setupWebapp();
+                runE2ETests(workerId);
+            }
+         }, onException);
+      };
+   }
+   parallel(jobs);
+}
+
+
+def runTests() {
+   try {
+     runAllTestClients();
+    } catch (TestsAreDone e) {
+      // Ignore this "error": it's thrown on successful test completion.
+      echo("Tests are done!");
+    }
+}
+
+
+def runE2ETests(workerId) {
+   echo("Starting e2e tests for worker ${workerId}");
+
+   // Determine which environment we're running against, so we can provide a tag
+   // in the LambdaTest build.
+   def e2eEnv = E2E_URL == "https://www.khanacademy.org" ? "prod" : "preprod";
+
+   // NOTE: We hard-code the values here as it is an experiment that will be
+   // removed soon.
+   def runE2ETestsArgs = ["CYPRESS_PROJECT_ID=2c1iwj && CYPRESS_RECORD_KEY=4c530cf3-79e5-44b5-aedb-f6f017f38cb5 && ./dev/cypress/e2e/tools/start-cypress-cloud-run.ts"];
+
+   dir('webapp/services/static') {
+      exec(runE2ETestsArgs);
+   }
+}
+
+// Determines if we are running the first or second smoke test.
+E2E_RUN_TYPE = (E2E_URL == "https://www.khanacademy.org" ? "second-smoke-test" : "first-smoke-test");
+
+onWorker(WORKER_TYPE, '5h') {     // timeout
+   notify([slack: [channel: params.SLACK_CHANNEL,
+                   thread: params.SLACK_THREAD,
+                   sender: 'Testing Turtle',
+                   emoji: ':turtle:',
+                   when: ['FAILURE', 'UNSTABLE']],
+           buildmaster: [sha: params.CYPRESS_GIT_REVISION,
+                         what: E2E_RUN_TYPE]]) {
+
+      initializeGlobals();
+
+      stage("Run e2e tests") {
+         runTests();
+      }
+   }
+}


### PR DESCRIPTION
## Summary:

Adds a temporary jenkins job to run e2e tests on Cypress Cloud. This job will be
removed once the tests are running successfully on Cypress Cloud.

The goal is to use parallel workers in Jenkins directly to run concurrent
cypress processes. This will allow us evaluate the performance of the tests
and the feasibility of switching to Cypress Cloud.

NOTE: I used the previous `e2e-test.groovy` template as reference: https://github.com/Khan/jenkins-jobs/blob/fc496e120f19c439348ae4136a0f92c909b5ab2c/jobs/e2e-test.groovy

Issue: XXX-XXXX

## Test plan:

Make sure that the `CYPRESS_GIT_REVISION` parameter is set to the correct branch:
`cycloud-skipped`.

1. Run the job `e2e-test-cycloud` in Jenkins.
2. Verify that the tests are running on Cypress Cloud.