### PR TITLE
E2E Cypress Cloud follow up fixes

### DIFF
--- a/jobs/e2e-test-cycloud.groovy
+++ b/jobs/e2e-test-cycloud.groovy
@@ -172,10 +172,20 @@ def runE2ETests(workerId) {
 
    // NOTE: We hard-code the values here as it is an experiment that will be
    // removed soon.
-   def runE2ETestsArgs = ["env", "CYPRESS_PROJECT_ID=2c1iwj", "CYPRESS_RECORD_KEY=4c530cf3-79e5-44b5-aedb-f6f017f38cb5", "./dev/cypress/e2e/tools/start-cypress-cloud-run.ts"];
+   def runE2ETestsArgs = [
+      "./dev/cypress/e2e/tools/start-cypress-cloud-run.ts",
+      "--cyConfig baseUrl=\"${E2E_URL}\""
+   ];
 
    dir('webapp/services/static') {
-      exec(runE2ETestsArgs);
+      // We build the secrets first, so that we can create test users in our
+      // tests.
+      sh("yarn cypress:secrets");
+
+      withEnv(["CYPRESS_PROJECT_ID=2c1iwj",
+               "CYPRESS_RECORD_KEY=4c530cf3-79e5-44b5-aedb-f6f017f38cb5"]) {
+         exec(runE2ETestsArgs);
+      }
    }
 }
 

--- a/jobs/e2e-test-cycloud.groovy
+++ b/jobs/e2e-test-cycloud.groovy
@@ -152,12 +152,12 @@ def runAllTestClients() {
    for (i = 0; i < NUM_WORKER_MACHINES; i++) {
       def workerId = i;  // avoid scoping problems
       jobs["e2e-test-${workerId}"] = {
-         swallowExceptions({
-            onWorker(WORKER_TYPE, '2h') {
-                _setupWebapp();
-                runE2ETests(workerId);
-            }
-         }, onException);
+
+         onWorker(WORKER_TYPE, '2h') {
+               _setupWebapp();
+               runE2ETests(workerId);
+         }
+
       };
    }
    parallel(jobs);


### PR DESCRIPTION
## Summary:

Now that #254 was landed, we need to make some follow up fixes to the temporary
job that was added to the e2e-test-cycloud pipeline.

These changes are necessary to make the job work as expected.

https://jenkins.khanacademy.org/job/misc/job/e2e-test-cycloud/

Issue: XXX-XXXX

## Test plan:

1. Run the job in the pipeline
2. Verify that the job runs successfully
3. If there are any issues, make changes as necessary, click on the last job run, then click on the `Replay` button.
4. Paste the changes in the `Main Script` text area, then click on the `Run` button.
5. Verify that the job runs successfully