### PR TITLE
No longer create cloud-run tags on every deploy.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -490,18 +490,6 @@ def uploadGraphqlSafelist() {
 }
 
 
-def createCloudRunTags(){
-   echo("Creating Cloud Run tags.")
-   dir("webapp") {
-      // Note: we do not update tags on the modules that we are deploying,
-      // because they get assigned their tag at deploy-time, so doing it
-      // here would be redundant (and would actually conflict).
-      exec(["deploy/update_cloud_run_tags.py", NEW_VERSION,
-            "--modules_to_ignore", SERVICES.join(',')]);
-   }
-}
-
-
 // When we deploy a change to a service, it may change the overall federated
 // graphql schema. We store this overall schema in a version labeled json file
 // stored on GCS.
@@ -558,7 +546,6 @@ def deployAndReport() {
       parallel(jobs);
 
       parallel([
-         "create-cloud-run-tags": { createCloudRunTags(); },
          "update-graphql-safelist": { uploadGraphqlSafelist(); }
       ])
 

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -256,17 +256,6 @@ def deployToGatewayConfig() {
    }
 }
 
-def createCloudRunTags(){
-   echo("Creating Cloud Run tags.")
-   dir("webapp") {
-      // Note: we do not update tags on the modules that we are deploying,
-      // because they get assigned their tag at deploy-time, so doing it
-      // here would be redundant (and would actually conflict).
-      exec(["deploy/update_cloud_run_tags.py", VERSION,
-            "--modules_to_ignore", SERVICES.join(',')]);
-   }
-}
-
 // TODO(colin): these messaging functions are mostly duplicated from
 // deploy-webapp.groovy and deploy-history.groovy.  We should probably set up
 // an alertlib (or perhaps just slack messaging) wrapper, since similar
@@ -387,8 +376,6 @@ def deploy() {
       jobs["failFast"] = true;
 
       parallel(jobs);
-
-      createCloudRunTags();
 
       _sendSimpleInterpolatedMessage(
          alertMsgs.JUST_DEPLOYED.text,


### PR DESCRIPTION
## Summary:
Now that we are routing to cloud-run in fastly (and Go), we no longer
need to create tags on every deploy to help us with the routing.  Huzzah!

This needs to wait to deploy until we are fully off of VCL and not
going back.  Since we did not backport the route-to-cloud-run logic to
VCL.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10502

## Test plan:
I ran `groovy jobs/build-webapp.groovy` without any new errors.