### PR TITLE
Handle first E2E test skipped state

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -523,7 +523,7 @@ def verifySmokeTestResults(jobName, buildmasterFailures=0) {
          // if we improve the flakiness of smoke tests in the future
          // this should be changed to only allow the deploy job to
          // continue if a job has succeeded.
-         if (status in ["succeeded", "aborted", "failed", "killed"]) {
+         if (status in ["succeeded", "aborted", "failed", "killed", "skipped"]) {
             return;
          } else {
            // continue pinging once a minute until smoke tests succeed


### PR DESCRIPTION
## Summary:
Proceed to confirm set default prompt when first E2E test is in the new
state "skipped", which is added in:

https://github.com/Khan/buildmaster2/pull/219

https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2643591176/ADR+699+Allow+for+less-attended+and+unattended+deploys#Speed

Issue: https://khanacademy.atlassian.net/browse/INFRA-9995

Test plan:

Before buildmaster changes deployed:

1. `sun: queue foo` in #1s-and-0s-deploys
2. Open queue dialog
3. Fill out dialog and select None for user-facing level.
4. Proceed with deployment.
6. Verify deployment was successful.

After buildmaster changes deployed:

1. `sun: queue foo` in #1s-and-0s-deploys
2. Open queue dialog
3. Fill out dialog and select user-facing for user-facing level.
4. Proceed with deployment.
5. Verify first e2e tests were skipped.
6. Verify deployment was successful.