### PR TITLE
Don't call yarn directly in jenkins-jobs.

### DIFF
--- a/jobs/demo-district-update-pass.groovy
+++ b/jobs/demo-district-update-pass.groovy
@@ -40,13 +40,13 @@ BUILD_NAME = "build demo-district-password-update";
 def _setupWebapp() {
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", params.CYPRESS_GIT_REVISION);
    dir("webapp/services/static") {
-      sh("yarn install");
+      sh("make npm_deps");
    }
 }
 
 def runScript() {
    def workDir = "webapp/services/static/javascript/districts-package/__e2e-tests__";
-   def runCypressArgs = ["yarn",
+   def runCypressArgs = ["./dev/tools/run_pkg_script.sh",
                          "cypress",
                          "run", 
                          "--spec",

--- a/jobs/e2e-test-cycloud.groovy
+++ b/jobs/e2e-test-cycloud.groovy
@@ -142,7 +142,7 @@ def _setupWebapp() {
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", GIT_SHA1);
 
    dir("webapp/services/static") {
-      sh("yarn install --frozen-lockfile");
+      sh("make npm_deps");
    }
 }
 

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -162,7 +162,7 @@ def _setupWebapp() {
    kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", GIT_SHA1);
 
    dir("webapp/services/static") {
-      sh("yarn install --frozen-lockfile");
+      sh("make npm_deps");
    }
 }
 
@@ -193,7 +193,7 @@ def runLambdaTest() {
       fastlyComputeEnvironmentCookie = "ZTM3YmE2YTFjNDZkZjEwMDYxMTM3NzQyM2VlYjgw"
    }
 
-   def runLambdaTestArgs = ["yarn",
+   def runLambdaTestArgs = ["./dev/tools/run_pkg_script.sh",
                             "lambdatest",
                             "--envs='FASTLY_COMPUTE_ENVIRONMENT_COOKIE=${fastlyComputeEnvironmentCookie}'",
                             "--cy='--config baseUrl=\"${E2E_URL}\",retries=${params.TEST_RETRIES}'",

--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -321,7 +321,7 @@ update_caniuse() {
     #    https://github.com/facebook/create-react-app/issues/6708#issuecomment-488392836
     (
         cd webapp
-        for d in `git grep -l caniuse-lite "*yarn.lock" | xargs -n1 dirname`; do
+        for d in `git grep -l caniuse-lite "*yarn.lock" "*pnpm-lock.yaml" | xargs -n1 dirname`; do
             (
                 cd "$d"
                 # Use the official tool to update the browserslist and caniuse-lite packages.
@@ -329,7 +329,7 @@ update_caniuse() {
             )
         done
     )
-    jenkins-jobs/safe_git.sh commit_and_push webapp -m "Automatic update of caniuse, via $0" '*/yarn.lock'
+    jenkins-jobs/safe_git.sh commit_and_push webapp -m "Automatic update of caniuse, via $0" '*/yarn.lock' '*/pnpm-lock.yaml'
 }
 
 


### PR DESCRIPTION
## Summary:
This is a follow-up to:
https://github.com/Khan/webapp/pull/28829

I changed the few places where we install packages to use `make npm_deps` instead. The two places where we were calling a yarn script I now use the new shell script for this, instead. This is all in service of moving off of yarn v1 to pnpm v10 instead.

Issue: FEI-6143

## Test plan:
Will need to deploy the webapp changes first. But I'm a bit unclear on how to best test this!