### PR TITLE
Add job to validate exercise IDs in assessments

### DIFF
--- a/jobs/check-assessment-exercise-ids.groovy
+++ b/jobs/check-assessment-exercise-ids.groovy
@@ -7,7 +7,9 @@
 import org.khanacademy.Setup;
 
 
-new Setup(steps).apply();
+new Setup(steps).addCronSchedule(
+   '0 * * * *' // Run every hour
+).apply();
 
 
 def _setupWebapp() {
@@ -20,7 +22,7 @@ def _setupWebapp() {
 def runScript() {
    withTimeout('1h') {
       dir("webapp") {
-         sh("go run services/assessments/cmd/check_assessments_exercise_ids/main.go");
+         exec(["go", "run", "services/assessments/cmd/check_assessments_exercise_ids/main.go"]);
       }
    }
 }

--- a/jobs/check-assessment-exercise-ids.groovy
+++ b/jobs/check-assessment-exercise-ids.groovy
@@ -34,7 +34,7 @@ onMaster('1h') {
       stage("Initializing webapp") {
          _setupWebapp();
       }
-      stage("Notifying") {
+      stage("Running script") {
          runScript();
       }
    }

--- a/jobs/check-assessment-exercise-ids.groovy
+++ b/jobs/check-assessment-exercise-ids.groovy
@@ -1,0 +1,41 @@
+// Loads all the assessment configs from datastore and checks to make sure that
+// their ExerciseIDs are valid (i.e., that there are published exercises with
+// those IDs).
+
+@Library("kautils")
+// Classes we use, under jenkins-jobs/src/.
+import org.khanacademy.Setup;
+
+
+new Setup(steps).apply();
+
+
+def _setupWebapp() {
+   withTimeout('1h') {
+      kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", "master");
+   }
+}
+
+
+def runScript() {
+   withTimeout('1h') {
+      dir("webapp") {
+         sh("go run services/assessments/cmd/check_assessments_exercise_ids/main.go");
+      }
+   }
+}
+
+
+onMaster('1h') {
+   notify([slack: [channel: '#assessments-alerts',
+                   sender: 'Assessment Config Anaconda',
+                   emoji: ':snake:',
+                   when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {
+      stage("Initializing webapp") {
+         _setupWebapp();
+      }
+      stage("Notifying") {
+         runScript();
+      }
+   }
+}


### PR DESCRIPTION
## Summary:
Our interim assessments contain exercise IDs that we use to look up content, and we need to be alerted if any of those IDs become invalid. This job checks for invalid exercise IDs and alerts us if it finds any.

Issue: INFRA-10509

## Test plan:
Verify that the job ran correctly [in Jenkins](https://jenkins.khanacademy.org/job/misc/job/check-assessment-exercise-ids/). Note that the failure is intended - I made a test configuration invalid to ensure the alert would work.