### PR TITLE
Prevent e2e-test-cycloud from overwriting smoke test result in buildmaster

### DIFF
--- a/jobs/e2e-test-cycloud.groovy
+++ b/jobs/e2e-test-cycloud.groovy
@@ -277,16 +277,18 @@ def analyzeResults(foldersList) {
 }
 
 // Determines if we are running the first or second smoke test.
-E2E_RUN_TYPE = (E2E_URL == "https://www.khanacademy.org" ? "second-smoke-test" : "first-smoke-test");
+// E2E_RUN_TYPE = (E2E_URL == "https://www.khanacademy.org" ? "second-smoke-test" : "first-smoke-test");
 
 onWorker(WORKER_TYPE, '5h') {     // timeout
    notify([slack: [channel: params.SLACK_CHANNEL,
                    thread: params.SLACK_THREAD,
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
-                   when: ['FAILURE', 'UNSTABLE']],
-           buildmaster: [sha: params.GIT_REVISION,
-                         what: E2E_RUN_TYPE]]) {
+                   when: ['FAILURE', 'UNSTABLE']]]) {
+      // TODO(nathanjd): Restore notify to buildmaster once this replaces
+      // e2e-test.groovy.
+      // buildmaster: [sha: params.GIT_REVISION,
+      //                   what: E2E_RUN_TYPE]
       echo("GIT_REVISION: ${params.GIT_REVISION}");
       initializeGlobals();
       stage("Run e2e tests") {


### PR DESCRIPTION
## Summary:
If e2e-test-cycloud finishes after e2e-test, it will overwrite both the
result and job ID.

This has been causing 2 bugs:

1. The link to the e2e job in jenkins points to e2e-test but with the
   e2e-test-cycloud job id. Resulting in a dead link.
2. The status of the smoke test in buildmaster is failed when e2e-test
   passes but e2e-test-cycloud fails.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1740083704822279?thread_ts=1739930668.893529&cid=C096UP7D0

## Test plan:
Monitor deployment queue.