### PR TITLE
use safePull instaed of safePullInBranch

### DIFF
--- a/jobs/e2e-test-cycloud.groovy
+++ b/jobs/e2e-test-cycloud.groovy
@@ -261,7 +261,7 @@ def analyzeResults(foldersList) {
    }
 
    // report-merged-results.ts is a new file
-   kaGit.safePullInBranch("webapp/services/static/dev/cypress/e2e/tools", params.GIT_REVISION);
+   kaGit.safePull("webapp/services/static/dev/cypress/e2e/tools");
 
    dir ('webapp/services/static') {
       sh("ls ./dev/cypress/e2e/tools");


### PR DESCRIPTION
## Summary:
use safePull instead of safePullInBranch due to rebase issue

safePullInBranch was causing an issue:
```
00:04:56.250  + _rebase a5ade2bbc577a327bb69c63ea97c6ce7c419688f
00:04:56.250  + timeout 10m git rebase origin/a5ade2bbc577a327bb69c63ea97c6ce7c419688f
00:04:56.250  fatal: invalid upstream 'origin/a5ade2bbc577a327bb69c63ea97c6ce7c419688f'
00:04:56.250  + timeout 10m git rebase --abort
00:04:56.250  fatal: No rebase in progress?
```

Issue: none

## Test plan:
ran test on test job