### PR TITLE
[🔥AUDIT🔥] Make sure Jenkink's BUILD_TAG var doesn't conflict with ours.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -40,7 +40,10 @@ def runScript() {
    dir("webapp") {
         try {
             // First, we need to get a local webserver running.
-            sh("ssh-agent make start-dev-server-backend WORKING_ON=NONE")
+            // We need the `env` because otherwise jenkins's
+            // BUILD_TAG takes precedence over our own.
+            // TODO(csilvers): clear more of env?
+            sh("ssh-agent env -u BUILD_TAG make start-dev-server-backend WORKING_ON=NONE")
             sh("rm -rf datastore")
             sh("mkdir -p datastore")
             sh("go run ./services/users/cmd/create_dev_users")


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
When Docker Compose sees sees an envvar defined both in the
(shell) environment and in an `.env` file, the environment wins:
   https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#ways-to-set-variables-with-interpolation

This means envvars that Jenkins sets can interfere with our running
Docker.  And this is indeed what happened.

Issue: https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1535/console

## Test plan:
Fingers crossed, will try again.