### PR TITLE
[🔥AUDIT🔥] We need an ssh-agent whenever we do docker stuff.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -54,7 +54,7 @@ def runScript() {
             sh("docker exec -i webapp-datastore-emulator-1 tar -C /var/datastore -c WEB-INF | gsutil cp - gs://${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar")
         } finally {
             // No matter what, we stop the local webserver.
-            sh("make stop-server")
+            sh("ssh-agent make stop-server")
         }
    }
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This was causing an error:
```
15:00:32  make -C dev/server stop
15:00:32  make[1]: Entering directory '/home/ubuntu/webapp-workspace/webapp/dev/server'
15:00:32  docker compose \
15:00:32       -f docker-compose.all-modes.yml  -f docker-compose.backend.yml  -f docker-compose.frontend.yml  -f ../../genfiles/devserver/docker-compose.working-on.yml \
15:00:32      -p webapp \
15:00:32      --project-directory ../.. \
15:00:32      --env-file ../../genfiles/devserver/docker-compose.env \
15:00:32      down
15:00:32  time="2025-03-06T15:00:31-08:00" level=warning msg="The \"SSH_AUTH_SOCK\" variable is not set. Defaulting to a blank string."
15:00:32  time="2025-03-06T15:00:31-08:00" level=warning msg="The \"SSH_AUTH_SOCK\" variable is not set. Defaulting to a blank string."
15:00:32  time="2025-03-06T15:00:31-08:00" level=warning msg="The \"SSH_AUTH_SOCK\" variable is not set. Defaulting to a blank string."
15:00:32  time="2025-03-06T15:00:31-08:00" level=warning msg="The \"SSH_AUTH_SOCK\" variable is not set. Defaulting to a blank string."
15:00:32  invalid spec: :/run/host-services/ssh-auth.sock:cached: empty section between colons
```

Issue: https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1536/console

## Test plan:
Will try deploying again.