### PR TITLE
Fix the build-current-sqlite script to actually work.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -57,16 +57,15 @@ def runScript() {
             sh("ssh-agent env -u BUILD_TAG make start-dev-server-backend WORKING_ON=NONE")
 
             updateDatabase()
-
-            // Now upload the new database to gcs.
-            sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak")
-            // A rare case we *don't* want the `-t` flag to docker:
-            // if we include it, tar refuses to emit output to a terminmal.
-            sh("docker exec -i webapp-datastore-emulator-1 tar -C /var/datastore -c . | gsutil cp - ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar")
         } finally {
             // No matter what, we stop the local webserver.
             sh("ssh-agent make stop-server")
         }
+        // Now upload the new database to gcs.
+        sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak")
+        // A rare case we *don't* want the `-t` flag to docker:
+        // if we include it, tar refuses to emit output to a terminmal.
+        sh("docker exec -i webapp-datastore-emulator-1 tar -C /var/datastore -c . | gsutil cp - ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar")
    }
 }
 

--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -35,8 +35,8 @@ that haven't yet been merged to master.""",
 
 // This runs in webapp/.
 def updateDatabase() {
-    sh("go run ./services/users/cmd/create_dev_users")
-    sh("go run ./services/admin/cmd/make_admin -username testadmin")
+   sh("go run ./services/users/cmd/create_dev_users")
+   sh("go run ./services/admin/cmd/make_admin -username testadmin")
 }
 
 def runScript() {
@@ -44,15 +44,22 @@ def runScript() {
                           params.GIT_REVISION);
 
    dir("webapp") {
+        // Let's make sure we have a recent version of the datastore first.
+        sh("rm -rf datastore")
+        sh("make current.sqlite")
         try {
-            // First, we need to get a local webserver running.
-            // We need the `env` because otherwise jenkins's
-            // BUILD_TAG takes precedence over our own.
+            // First, we need to get a local webserver running.  We
+            // need the `ssh-agent` because apparently jenkins don't
+            // have one by default, and our docker rules use it.  We
+            // need the `env` because otherwise jenkins's BUILD_TAG
+            // takes precedence over our own.
             // TODO(csilvers): clear more of env?
             sh("ssh-agent env -u BUILD_TAG make start-dev-server-backend WORKING_ON=NONE")
+
             updateDatabase()
+
             // Now upload the new database to gcs.
-            sh("gsutil cp gs://${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar gs://${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak")
+            sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak")
             // A rare case we *don't* want the `-t` flag to docker:
             // if we include it, tar refuses to emit output to a terminmal.
             sh("docker exec -i webapp-datastore-emulator-1 tar -C /var/datastore -c . | gsutil cp - ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar")
@@ -62,7 +69,6 @@ def runScript() {
         }
    }
 }
-
 
 // We run on a special worker machine because starting up all the
 // dev backends requires hefty resources.


### PR DESCRIPTION
## Summary:
It had a few problems:

1. It tried to delete the database file after starting the datastore
emulator.  That ain't gonna fly.  Instead, we have to depend on create_dev_users to properly delete old users before creating new ones (which it does).

2. I was using too many `gs://`'s in a row.

3. I was only putting the WEB_INF directory into the tar file, not all
the files that the datastore emulator creates.  This is problematic
because if not all the files are in the tarfile, the datastore
emulator will create them, and they will be owned by root, and we
won't be able to clean them up.

To bootstrap the solution to (3), I manually updated a new version of
dev_datastore.tar to gcs that has all the files in datastore/.  So
next time this script runs, it will populate datastore/ on the build
machine with all the files, and docker won't create any new files
(owned by root), it will just modify the existing files (owned by
jenkins).

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1741306004899129

## Test plan:
Ran this manually via jenkins replay at
   https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1541