### PR TITLE
Get rid of references to yarn.lock in our weekly-update script.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -329,7 +329,7 @@ update_caniuse() {
             )
         done
     )
-    jenkins-jobs/safe_git.sh commit_and_push webapp -m "Automatic update of caniuse, via $0" '*/yarn.lock' '*/pnpm-lock.yaml'
+    jenkins-jobs/safe_git.sh commit_and_push webapp -m "Automatic update of caniuse, via $0" '*/pnpm-lock.yaml'
 }
 
 


### PR DESCRIPTION
## Summary:
We're fully on pnpm now, and yarn.lock doesn't exist anymore.
Checking for it caused the job to fail.

Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/352/execution/node/1229/log/

## Test plan:
Fingers crossed for next run.