### PR TITLE
Do not include existing datastore archive in new datastore archives

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -65,7 +65,7 @@ def runScript() {
         sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak")
         // A rare case we *don't* want the `-t` flag to docker:
         // if we include it, tar refuses to emit output to a terminmal.
-        sh("docker exec -i webapp-datastore-emulator-1 tar -C /var/datastore -c . | gsutil cp - ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar")
+        sh("docker exec -i webapp-datastore-emulator-1 tar --exclude dev_datastore.tar -C /var/datastore -c . | gsutil cp - ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar")
    }
 }
 


### PR DESCRIPTION
## Summary:
It looks like the current datastore archive in GCS contains a previous version
of the archive[1]. This is because we download the previous version of the
archive into the same directory being archived. It looks like this change was
introduced in #285, and March 9th was the last day we successfully generated a
new archive.

This PR excludes the previous archive file when creating the new archive.

[1] https://khanacademy.slack.com/archives/C02NMB1R5/p1741838164634579?thread_ts=1741827828.632279&cid=C02NMB1R5

Issue: XXX-XXXX

## Test plan:
I downloaded the existing archive:
```
cd datastore
gsutil cp gs://ka_dev_sync/dev_datastore.tar .
```
and then ran:
```
tar --exclude dev_datastore.tar -C datastore -c . | tar tv
```
This shows that the archive created with the new --exclude flag indeed doesn't
create the existing archive.