### PR TITLE
Re-added slack notifications from webapp script

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -239,6 +239,8 @@ def runE2ETests(workerId) {
       "./dev/cypress/e2e/tools/start-cy-cloud-run.ts",
       "--url=${E2E_URL}",
       "--name=${BUILD_NAME}",
+      "--targets",
+      "mm-test-pass",
    ];
 
    dir('webapp/services/static') {
@@ -274,7 +276,7 @@ def analyzeResults(foldersList) {
 
    withTimeout('5m') {
       // several new files in util and tools
-      kaGit.safePull("webapp/services/static/dev/cypress/e2e/util");
+      kaGit.safePull("webapp/services/static/dev/cypress/e2e/tools");
       kaGit.safePull("webapp/services/static/dev/cypress/e2e/util");
 
       dir('webapp/services/static') {

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -239,8 +239,6 @@ def runE2ETests(workerId) {
       "./dev/cypress/e2e/tools/start-cy-cloud-run.ts",
       "--url=${E2E_URL}",
       "--name=${BUILD_NAME}",
-      "--targets",
-      "mm-test-pass",
    ];
 
    dir('webapp/services/static') {

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -287,7 +287,7 @@ def analyzeResults(foldersList) {
                "--channel", params.SLACK_CHANNEL,
                // The URL associated to this Jenkins build.
                "--build-url", env.BUILD_URL,
-               // The LambdaTest build name that will be included at the
+               // The Cypress Cloud build name that will be included at the
                // beginning of the message.
                "--label", BUILD_NAME,
                // The URL we test against.

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -292,7 +292,7 @@ def analyzeResults(foldersList) {
                "--label", BUILD_NAME,
                // The URL we test against.
                "--url", params.URL,
-               // Notify failures to DevOps and FEI
+               // folders with e2e results
                "--folders",
                *foldersList
             ];

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -272,18 +272,54 @@ def analyzeResults(foldersList) {
       return;
    }
 
-   // report-merged-results.ts is a new file
-   kaGit.safePull("webapp/services/static/dev/cypress/e2e/tools");
+   withTimeout('5m') {
+      // several new files in util and tools
+      kaGit.safePull("webapp/services/static/dev/cypress/e2e/util");
+      kaGit.safePull("webapp/services/static/dev/cypress/e2e/util");
 
-   dir ('webapp/services/static') {
-      sh("ls ./dev/cypress/e2e/tools");
-      // report-merged-results returns a non-zero rc if it detects test
-      // failures. We set the job to UNSTABLE in that case (since we don't
-      // consider smoketest failures to be blocking). But we still keep on
-      // running the rest of this script!
-      catchError(buildResult: "UNSTABLE", stageResult: "UNSTABLE",
-         message: "There were test failures!") {
-         exec(["npx", "--yes", "tsx", "./dev/cypress/e2e/tools/report-merged-results.ts", *foldersList]);
+      dir('webapp/services/static') {
+         // Get the SLACK_TOKEN from global credentials (env vars).
+         withCredentials([
+            string(credentialsId: "SLACK_BOT_TOKEN", variable: "SLACK_TOKEN")
+         ]) {
+            def notifyResultsArgs = [
+               "./dev/cypress/e2e/tools/notify-e2e-results.ts",
+               "--channel", params.SLACK_CHANNEL,
+               // The URL associated to this Jenkins build.
+               "--build-url", env.BUILD_URL,
+               // The LambdaTest build name that will be included at the
+               // beginning of the message.
+               "--label", BUILD_NAME,
+               // The URL we test against.
+               "--url", params.URL,
+               // Notify failures to DevOps and FEI
+               "--folders",
+               *foldersList
+            ];
+
+            if (params.DEPLOYER_USERNAME) {
+               // The deployer is the person who triggered the
+               // build (this is only included in the message if
+               // the e2e tests fail).
+               notifyResultsArgs += ["--deployer", params.DEPLOYER_USERNAME];
+            }
+            if (params.SLACK_THREAD) {
+               notifyResultsArgs += ["--thread", params.SLACK_THREAD];
+            }
+
+            // notify-e2e-results returns a non-zero rc if it detects test
+            // failures. We set the job to UNSTABLE in that case (since we don't
+            // consider smoketest failures to be blocking). But we still keep on
+            // running the rest of this script!
+            catchError(buildResult: "UNSTABLE", stageResult: "UNSTABLE",
+               message: "There were test failures!") {
+               exec(notifyResultsArgs);
+            }
+
+            // Let notify() know not to send any messages to slack, because we
+            // just did it here.
+            env.SENT_TO_SLACK = '1';
+         }
       }
    }
 }


### PR DESCRIPTION
## Summary:
re-added slack notifications from webapp script
currently, there is no tagged notification on e2e tests passing so deployers have missed the cue if they weren't paying super close attention

Issue: FEI-6290

## Test plan:
ran script on jenkins test job