### PR TITLE
Allow concurrent builds for delete-versions

### DIFF
--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -70,7 +70,7 @@ def deleteVersion() {
 }
 
 
-onWorker('30m') {
+onMaster('30m') {
    notify([slack: [channel: '#1s-and-0s-deploys',
                 sender: 'Mr Monkey',
                 emoji: ':monkey_face:',


### PR DESCRIPTION
## Summary:
I made some improvements to how reaper is triggering delete-versions [here](https://github.com/Khan/buildmaster2/pull/252), but there's still a chance that the queue could get backed up. To help prevent that, let's allow these builds to run concurrently. Reaper triggers separate jobs for each service, so it doesn't seem like there's any reason we should be forcing these to be run sequentially.

Issue: XXX-XXXX

## Test plan: