### PR TITLE
Allow versions for multiple services to be deleted in one job

### DIFF
--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -36,7 +36,7 @@ def verifyArgs() {
       notify.fail("The SERVICE_VERSIONS parameter is required.");
    }
    try {
-      def parsed = new JsonSlurper().parseText(params.SERVICE_VERSIONS);
+      def parsed = new JsonSlurperClassic().parseText(params.SERVICE_VERSIONS);
       if (!(parsed instanceof Map)) {
          notify.fail("SERVICE_VERSIONS must be a JSON object.");
       }


### PR DESCRIPTION
## Summary:
See https://github.com/Khan/buildmaster2/pull/253

We're having some issues with the queue on master getting a bit backlogged and it seems one of the causes is reaper. Every 15 minutes, reaper spins up several jobs (that only take a minute or so to run), but since the jobs are run sequentially, a backlog can build up if there's any slowness from jenkins. To remediate that, let's just trigger a single job that handles all services.

Issue: INFRA-XXXX

## Test plan:
Try running this job manually in jenkins using a replay