### PR TITLE
[FEI-6189] Disallow deploying frontend and backend changes at the same time.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -344,6 +344,17 @@ def initializeGlobals() {
             SERVICES = [];
          }
 
+         // If we're deploying static and other services at the same time,
+         // we want to disallow this as we're going to be moving the static
+         // service out of webapp. It can be overridden with the FORCE flag.
+         if ("static" in SERVICES && SERVICES.size() > 1 && !params.FORCE) {
+            notify.fail("You cannot deploy static and other services at " +
+                        "the same time. Please split apart your backend " +
+                        "and frontend changes into separate deploy branches. " +
+                        "If you must deploy them together, you can use the " +
+                        "'FORCE' flag.");
+         }
+
          // Now make the deps we need.  We always need python deps
          // because we ourselves run various python scripts
          // (e.g. current_version.py, below), but we only need other deps

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -328,6 +328,17 @@ def deploy() {
             SERVICES = params.SERVICES.split(",").collect { it.trim() };
          }
 
+         // If we're deploying static and other services at the same time,
+         // we want to disallow this as we're going to be moving the static
+         // service out of webapp. It can be overridden with the FORCE flag.
+         if ("static" in SERVICES && SERVICES.size() > 1 && !params.FORCE) {
+            notify.fail("You cannot deploy static and other services at " +
+                        "the same time. Please split apart your backend " +
+                        "and frontend changes into separate deploy branches. " +
+                        "If you must deploy them together, you can use the " +
+                        "'FORCE' flag.");
+         }
+
          // Make the deps we need based on what we're deploying.  The
          // python services (default/etc) only need python deps.  The
          // goliath services build their own deps via their `make deploy`


### PR DESCRIPTION
## Summary:
We want to disallow deploying frontend and backend changes together (in general and in preperation for moving the frontend code out into a new repo).

We're not going to deploy this until we're absolutely sure that we've figured out any edge cases, but it's likely that we're really close to deploying this.

All the changes we've made are in these two epics:
https://khanacademy.atlassian.net/browse/FEI-6194
https://khanacademy.atlassian.net/browse/FEI-6178

Issue: FEI-6189

## Test plan:
Not sure how to test this... I think this is syntactically correct, but I assume the test plan is probably deploying this and then confirming that a plain static (or non-static) deploy continues to work - and that a combination deploy correctly fails.