### PR TITLE
Post to `#whats-happening` when we deploy to fastly.

### DIFF
--- a/jobs/deploy-fastly.groovy
+++ b/jobs/deploy-fastly.groovy
@@ -169,9 +169,9 @@ def notifyWithVersionInfo(oldActive, newActive) {
    // automatically as part of the normal deploy process, and gets
    // alerted on #whats-happening via that mechanism.
    if (params.TARGET == "prod" && params.SERVICE != "khanacademy-org-compute") {
-      def subject = "Fastly service ${params.SERVICE} was modified.";
-      def body = "New version: ${newActive}";
-      def cmd = [
+      subject = "Fastly service ${params.SERVICE} was modified.";
+      body = "New version: ${newActive}";
+      cmd = [
           "jenkins-jobs/alertlib/alert.py",
           "--slack=#fastly",
           "--chat-sender=fastly",

--- a/jobs/deploy-fastly.groovy
+++ b/jobs/deploy-fastly.groovy
@@ -182,6 +182,15 @@ def notifyWithVersionInfo(oldActive, newActive) {
       withSecrets.slackAlertlibOnly() {
          sh("echo ${exec.shellEscape(body)} | ${exec.shellEscapeList(cmd)}");
       }
+
+      // Let's also keep track of what deploys we handled, to make it
+      // easier to find changes to fastly that did not go through this
+      // script.  Note that `>>` uses a buffered write so is safe even
+      // if two deploy scripts are running in parallel.  However, this
+      // does depend on this job only having one workspace, so we don't
+      // have to worry about jobs running in parallel in any case.
+      // (and note we do not enable concurrent builds in our setup call.)
+      sh("echo '${params.SERVICE}:${params.TARGET}:${newActive}' >> '${env.WORKSPACE}/deployed_versions.txt'");
    }
 }
 

--- a/jobs/deploy-fastly.groovy
+++ b/jobs/deploy-fastly.groovy
@@ -163,6 +163,26 @@ def notifyWithVersionInfo(oldActive, newActive) {
    withSecrets.slackAlertlibOnly() {
       sh("echo ${exec.shellEscape(body)} | ${exec.shellEscapeList(cmd)}");
    }
+
+   // Let's tell #whats-happening as well, at least for prod deploys.
+   // But we don't alert for fastly-compute, since that is deployed
+   // automatically as part of the normal deploy process, and gets
+   // alerted on #whats-happening via that mechanism.
+   if (params.TARGET == "prod" && params.SERVICE != "khanacademy-org-compute") {
+      def subject = "Fastly service ${params.SERVICE} was modified.";
+      def body = "New version: ${newActive}";
+      def cmd = [
+          "jenkins-jobs/alertlib/alert.py",
+          "--slack=#fastly",
+          "--chat-sender=fastly",
+          "--icon-emoji=:fastly:",
+          "--severity=info",
+          "--summary=${subject}",
+      ];
+      withSecrets.slackAlertlibOnly() {
+         sh("echo ${exec.shellEscape(body)} | ${exec.shellEscapeList(cmd)}");
+      }
+   }
 }
 
 onMaster('30m') {


### PR DESCRIPTION
## Summary:
We have a goal of posting to the `#whats-happening` slack channel
whenever we deploy a change to our production system.  Currently,
changes to our fastly configs are noticed, via polling, by a cronjob
running on toby.  But now that all fastly deploys are (supposed to) go
through this jenkins job, it can do the reporting to #whats-happening
instead!

Once this is live, I'll disable the toby cronjob.  Or rather, I'll
repurpose it to notice when deploys to fastly are made via the UI and
not via the fastly deploy process.

Issue: https://khanacademy.slack.com/archives/C06T4JE5HCN/p1741644811156629

## Test plan:
Fingers crossed, we'll see what happens next time we need to deploy
prod vcl!