### PR TITLE
Avoid passing in out of date param to display name

### DIFF
--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -28,6 +28,9 @@ Example: {"serviceA": ["version1", "version2"], "serviceB": ["version3"]}""",
 
 ).apply();
 
+currentBuild.displayName = "${currentBuild.displayName} (${params.SERVICE_VERSIONS})";
+
+
 def verifyArgs() {
    if (!params.SERVICE_VERSIONS) {
       notify.fail("The SERVICE_VERSIONS parameter is required.");


### PR DESCRIPTION
## Summary:
I missed a reference to an old param. This isn't causing any failures, but all jobs have `(null)` in the display name now

Issue: INFRA-XXXX

## Test plan: