### PR TITLE
[🔥AUDIT🔥] Fix the command that copies current.sqlite to gcs.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -35,8 +35,8 @@ that haven't yet been merged to master.""",
 
 // This runs in webapp/.
 def updateDatabase() {
-   sh("go run ./services/users/cmd/create_dev_users")
-   sh("go run ./services/admin/cmd/make_admin -username testadmin")
+   sh("go run ./services/users/cmd/create_dev_users");
+   sh("go run ./services/admin/cmd/make_admin -username testadmin");
 }
 
 def runScript() {
@@ -44,28 +44,29 @@ def runScript() {
                           params.GIT_REVISION);
 
    dir("webapp") {
-        // Let's make sure we have a recent version of the datastore first.
-        sh("rm -rf datastore")
-        sh("make current.sqlite")
-        try {
-            // First, we need to get a local webserver running.  We
-            // need the `ssh-agent` because apparently jenkins don't
-            // have one by default, and our docker rules use it.  We
-            // need the `env` because otherwise jenkins's BUILD_TAG
-            // takes precedence over our own.
-            // TODO(csilvers): clear more of env?
-            sh("ssh-agent env -u BUILD_TAG make start-dev-server-backend WORKING_ON=NONE")
+      // Let's make sure we have a recent version of the datastore first.
+      sh("rm -rf datastore");
+      sh("make current.sqlite");
+      try {
+         // First, we need to get a local webserver running.  We
+         // need the `ssh-agent` because apparently jenkins don't
+         // have one by default, and our docker rules use it.  We
+         // need the `env` because otherwise jenkins's BUILD_TAG
+         // takes precedence over our own.
+         // TODO(csilvers): clear more of env?
+         sh("ssh-agent env -u BUILD_TAG make start-dev-server-backend WORKING_ON=NONE");
 
-            updateDatabase()
-        } finally {
-            // No matter what, we stop the local webserver.
-            sh("ssh-agent make stop-server")
-        }
-        // Now upload the new database to gcs.
-        sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak")
-        // A rare case we *don't* want the `-t` flag to docker:
-        // if we include it, tar refuses to emit output to a terminmal.
-        sh("docker exec -i webapp-datastore-emulator-1 tar --exclude dev_datastore.tar -C /var/datastore -c . | gsutil cp - ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar")
+         updateDatabase();
+
+         // Now upload the new database to gcs.
+         sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak");
+         // A rare case we *don't* want the `-t` flag to docker:
+         // if we include it, tar refuses to emit output to a terminmal.
+         sh("docker exec -i webapp-datastore-emulator-1 tar --exclude dev_datastore.tar -C /var/datastore -c . | gsutil cp - ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar");
+      } finally {
+          // No matter what, we stop the local webserver.
+         sh("ssh-agent make stop-server");
+      }
    }
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This command accesses the docker datastore-emulator container.  So it
needs to run while the containers are still up!  Not after they are
taken down.  Silly craig.

Issue: https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1543/console

## Test plan:
Mostly fingers crossed, I will try running the command again.