### PR TITLE
Make sure the datastore is synced to disk before copying it to gcs.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -58,6 +58,10 @@ def runScript() {
 
          updateDatabase();
 
+         // I don't know a better way to flush the datastore
+         // changes to disk, than to just kill it.
+         sh("docker exec -it webapp-datastore-emulator-1 dash -c 'kill `ls -l /proc/*/exe | grep java- | cut -d/ -f3`'")
+
          // Now upload the new database to gcs.
          sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak");
          // A rare case we *don't* want the `-t` flag to docker:

--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -60,7 +60,7 @@ def runScript() {
 
          // I don't know a better way to flush the datastore
          // changes to disk, than to just kill it.
-         sh("docker exec -it webapp-datastore-emulator-1 dash -c 'kill `ls -l /proc/*/exe | grep java- | cut -d/ -f3`'")
+         sh("docker exec webapp-datastore-emulator-1 dash -c 'kill `ls -l /proc/*/exe | grep java- | cut -d/ -f3`'")
 
          // Now upload the new database to gcs.
          sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.bak");


### PR DESCRIPTION
## Summary:
Users were seeing issues where the current.sqlite that they downloaded
from gcs had a `testadmin` user without admin permissions.  I could
see from the jenkins logs that we were running the grant-permissions
script, and it was finishing successfully, so my best theory as to
what is going wrong is that those changes weren't being fully flushed
to disk before we copied the db file to gcs.

I now add a command that I _hope_ will cause such flushing to happen.
Sadly, I couldn't find a supported way to flush the db or even stop
it, so I'm hoping that `kill` does the right thing.  It has to, right?

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1742583382311709?thread_ts=1742502207.930369&cid=C04SEFXQBNU

## Test plan:
I ran this new script manually, using replay, at
   https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1547/console

I then ran:
```
make stop-server
make current.sqlite
make serve-backend WORKING_ON=none
```
and visited `https://khanacademy.dev` and logged in as testadmin, and
visited /devadmin/users with success.

Subscribers: @jennylihan, @rjcorwin