### PR TITLE
[🔥AUDIT🔥] Make sure to sync webapp when generating the skipped list too.

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -343,6 +343,7 @@ onWorker(WORKER_TYPE, '5h') {     // timeout
                          what: E2E_RUN_TYPE]]) {
       initializeGlobals();
       stage("Generate skipped list") {
+         _setupWebapp();
          dir("webapp/services/static") {
             sh("pnpm cypress:clean");
             exec(["./dev/cypress/e2e/tools/gen-skipped-e2e-tests.js", "${E2E_URL}"]);


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In e2e tests, we were only syncing webapp on the workers actually
running the tests.  But we need to do it on the "orchestrator" machine
too!

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1742922725261679

## Test plan:
Fingers crossed

Subscribers: @somewhatabstract