### PR TITLE
Compute services to deploy during merge-branches

### DIFF
--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -123,13 +123,22 @@ def notifyStatus(job, result, sha1) {
    return _makeHttpRequestAndAlert("commits", "PATCH", params);
 }
 
-def notifyMergeResult(commitId, result, sha1, gae_version_name) {
+def notifyMergeResult(
+   String commitId,
+   String result,
+   String sha1 = null,
+   String gae_version_name = null,
+   String services = null
+) {
    echo("Marking commit #${commitId} as ${result}: ${sha1}");
    def params = [
       commit_id: commitId,
       result: result,
       git_sha: sha1,
       gae_version_name: gae_version_name
+      // TODO(INFRA-10586): Send services to buildmaster after it starts sending
+      // the correct params.BASE_REVISION and params.SERVICES to merge-branches.
+      // services: services
    ];
    return _makeHttpRequestAndAlert("commits/merge", "PATCH", params);
 }


### PR DESCRIPTION
## Summary:
To simplify the logic for automated aborts when doing an unattended
deploy, we should tell buildmaster what services a deploy should be
deploying during merge-branches instead of during build-webapp. This is
so failures during build-webapp or webapp-test (run in parallel) always
have access to the list of services and therefore the computed
attendedness value.

This change will happen in 5 stages:

1. Deploy this PR to declare the new parameters for merge-branches. This
   will also allow the services output to be checked in the logs.
   merge-branches will not send services to buildmaster at this time.
2. Update buildmaster to pass in the new parameters params.SERVICES and
   params.BASE_REVISION to merge-branches and accept services from
   PATCH /commits/merge.
3. Update merge-branches to send the list of services to buildmaster. At
   this time, build-webapp should overwrite the same services.
4. Update buildmaster to send the list of services received from 
    merge-branches to build-webapp so it doesn't need to recompute them.
5. Update build-webapp to no longer run webapp/deploy/should_deploy.py.

4 and 5 don't need to be done immediately, but should be done soon to
speed deployments up.

Unfortunately, adding the webapp/deploy/should_deploy.py call to
merge-branches adds ~40 seconds to its execution time. Bringing the
total from ~5 seconds to ~45 seconds. This is increased to 90 seconds if
the virtual environment must built from scratch. Hopefully, we make this
time back in aggregate by removing it from build-webapp and being able
to dequeue unattended builds sooner.

An example replay execution of merge-branches with this code is here:

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/298367/

Issue: https://khanacademy.atlassian.net/browse/INFRA-10586

Test plan:

1. Deploy to buildmaster prod.
2. Queue a static-only deploy in #1s-and-0s-deploys.
3. Verify merge-branches was successful.
4. Verify in the merge-branches logs that the services were correctly
   detected as "static".
5. Dequeue