### PR TITLE
Add determine-webapp-services job

### DIFF
--- a/jobs/determine-webapp-services.groovy
+++ b/jobs/determine-webapp-services.groovy
@@ -1,0 +1,162 @@
+// Determine what services would be deployed by a webapp commit. Should not
+// be started if the deployer has queued with the SERVICES flag because that
+// flag would override the result of this job.
+
+@Library("kautils")
+// Classes we use, under jenkins-jobs/src/.
+import org.khanacademy.Setup;
+// Vars we use, under jenkins-jobs/vars/.  This is just for documentation.
+//import vars.buildmaster
+//import vars.exec
+//import vars.kaGit
+//import vars.notify
+//import vars.withTimeout
+
+new Setup(steps
+
+).allowConcurrentBuilds(
+
+).addStringParam(
+    "GIT_REVISION",
+    """<b>REQUIRED</b>. The sha1 to determine the deployed services for.""",
+    ""
+
+).addStringParam(
+   "BASE_REVISION",
+   """Compute services that would be deployed by the commit since this 
+   revision based on the the commits between BASE_REVISION..GIT_REVISION.""",
+   ""
+
+).addStringParam(
+   "DEPLOYER_USERNAME",
+   """Who asked to run this job, used to ping on slack.
+If not specified, guess from the username of the person who started
+this job in Jenkins.  Typically not set manually, but by hubot scripts
+such as sun.  You can, but need not, include the leading `@`.""",
+   ""
+
+).addStringParam(
+   "SLACK_CHANNEL",
+   "The slack channel to which to send failure alerts.",
+   "#1s-and-0s-deploys"
+
+).addStringParam(
+   "SLACK_THREAD",
+   """The slack thread (must be in SLACK_CHANNEL) to which to send failure
+alerts.  By default we do not send in a thread.  Generally only set by the
+buildmaster, to the 'thread_ts' or 'timestamp' value returned by the Slack
+API.""", 
+   ""
+
+).addStringParam(
+   "REVISION_DESCRIPTION",
+   """Set by the buildmaster to give a more human-readable description
+of the GIT_REVISION, especially if it is a commit rather than a branch.""",
+   ""
+
+).addStringParam(
+   "BUILDMASTER_DEPLOY_ID",
+   """Set by the buildmaster, can be used by scripts to associate jobs
+that are part of the same deploy.  Write-only; not used by this script.""",
+   ""
+
+).addStringParam(
+  "JOB_PRIORITY",
+  """The priority of the job to be run (a lower priority means it is run
+sooner). The Priority Sorter plugin reads this parameter in to reorder jobs
+in the queue accordingly. Should be set to 3 if the job is depended on by
+the currently deploying branch, otherwise 6. Legal values are 1
+through 11. See https://jenkins.khanacademy.org/advanced-build-queue/
+for more information.""",
+  "6"
+
+).apply();
+
+currentBuild.displayName = ("${currentBuild.displayName} " +
+                            "(${params.REVISION_DESCRIPTION})");
+
+def checkArgs() {
+   if (!params.GIT_REVISION) {
+      notify.fail('The GIT_REVISION parameter is required.');
+   }
+}
+
+def checkoutWebapp() {
+   deployer_username = notify.getDeployerUsername(params.DEPLOYER_USERNAME)
+    
+   // TODO(csilvers): have these return an error message instead of alerting 
+   // themselves, so we can use notify.fail().
+   withEnv(["SLACK_CHANNEL=${params.SLACK_CHANNEL}",
+            "SLACK_THREAD=${params.SLACK_THREAD}",
+            "DEPLOYER_USERNAME=${deployer_username}",
+            "JOB_PRIORITY=${params.JOB_PRIORITY}"]) {
+      kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
+                             params.GIT_REVISION)
+   }
+}
+
+String[] determineServicesToDeploy() {
+   withVirtualenv.python3() {
+      withTimeout('15m') {
+         dir('webapp') {
+            echo('Determining services that should be deployed.')
+            String[] services = []
+
+            try {
+               String[] shouldDeployArgs = ['deploy/should_deploy.py'];
+               // Diff against BASE_REVISION if set.
+               if (params.BASE_REVISION) {
+                     shouldDeployArgs += [
+                        '--from-commit', params.BASE_REVISION]
+               }
+               services = exec.outputOf(shouldDeployArgs).split('\n');
+            } catch(e) {
+               notify.fail('Automatic detection of what to deploy ' +
+                           'failed. You can likely work around this ' +
+                           'by setting services on your deploy; ' +
+                           "see ${env.BUILD_URL}rebuild for " +
+                           'documentation, and `sun: help flags` ' +
+                           "for how to set it. If you aren't sure, " + 
+                           'ask deploy-support for help!');
+            }
+
+            if (services == [""]) {
+               // The above could be [""] if we should deploy nothing. We want 
+               // to use [] instead of [""].
+               services = [];
+            }
+
+            echo("Should deploy services: ${services.join(', ')}");
+            return services
+         }
+      }
+   }
+}
+
+
+// We use a build worker, because this is a CPU-heavy job and want to run 
+// several at a time.
+onWorker('build-worker', '1h') {
+   notify([slack: [channel: params.SLACK_CHANNEL,
+                   thread: params.SLACK_THREAD,
+                   sender: 'Mr Monkey',
+                   emoji: ':monkey_face:',
+                   when: ['FAILURE', 'UNSTABLE']],
+                   buildmaster: [sha: params.GIT_REVISION,
+                                 what: 'determine-webapp-services']]) {
+      checkArgs();
+
+      stage('Checkout webapp') {
+         checkoutWebapp()
+      }
+
+      String[] services = []
+      stage('Determine services') {
+         services = determineServicesToDeploy();
+      }
+
+      // Phone home the list of services to buildmaster.
+      buildmaster.notifyServices(params.GIT_REVISION,
+                                 services.join(', ') ?: 'tools-only');
+    }
+}

--- a/vars/notify.groovy
+++ b/vars/notify.groovy
@@ -133,6 +133,26 @@ def _sendToAlertlib(subject, severity, body, extraFlags) {
 }
 
 
+// Return the deployer username, ensuring it begins with @ and falling back to
+// the jenkins build user ID if no username is passed.
+String getDeployerUsername(String deployerUsernameParam) {
+   String deployerUsername = null
+   if (deployerUsernameParam) {
+      deployerUsername = deployerUsernameParam;
+   } else {
+      wrap([$class: 'BuildUser']) {
+         // It seems like BUILD_USER_ID is typically an email address.
+         deployerUsername = env.BUILD_USER_ID.split("@")[0];
+      }
+   }
+
+   if (!deployerUsername.startsWith("@") &&
+       !deployerUsername.startsWith("<@")) {
+      deployerUsername = "@${deployerUsername}";
+   }
+   return deployerUsername
+}
+
 // Supported options:
 // channel (required): what slack channel to send to
 // when (required): under what circumstances to send to slack; a list.


### PR DESCRIPTION
## Summary:
To simplify the logic for automated dequeues when doing an unattended
deploy, we should tell buildmaster what services a deploy should be
deploying before starting build-webapp. This is so failures during
build-webapp always have access to the list of services and therefore
the computed attendedness value.

Failures in webapp-test may need to trigger this job early in order to
tell if it should dequeue.

This job should not be started if the deployer has queued with the
SERVICES flag because that flag would override the result of this job.

This change will happen in 4 stages:

1. Deploy this PR to to perform testing with manual builds.
2. Update buildmaster to represent and call this job with a new state
   machine. At this time, build-webapp should overwrite the same
   services.
3. Update buildmaster to send the list of services received from this
   job to build-webapp so it doesn't need to recompute them.
4. Update build-webapp to no longer run webapp/deploy/should_deploy.py.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10586

## Test plan:
1. Deploy jenkins job.
2. Manually start builds for the job.
3. Verify the list of services is output correctly into the logs.