### PR TITLE
Add environment variable for jenkins-deploy service account auth to jenkins server

### DIFF
--- a/vars/onWorker.groovy
+++ b/vars/onWorker.groovy
@@ -42,7 +42,6 @@ def call(def label, def timeoutString, Closure body) {
       // To export BOTO_CONFIG, for some reason, worker did not
       // source the .profile or .bashrc anymore.
       withEnv(["BOTO_CONFIG=/home/ubuntu/.boto",
-               "GOOGLE_APPLICATION_CREDENTIALS=${env.HOME}/jenkins-deploy-gcloud-service-account.json",
                "PATH=" +
                "/home/ubuntu/webapp-workspace/devtools/khan-linter/bin:" +
                "/var/lib/jenkins/repositories/khan-linter/bin" +


### PR DESCRIPTION
## Summary:
Apparently [jenkins jobs don't source ~/.profile](https://github.com/Khan/aws-config/pull/145#discussion_r2021785324), so the `GOOGLE_APPLICATION_CREDENTIALS` env var needs to be defined at runtime. This env var points to the auth json used for gcp authentication by gcloud and gcp SDKs. It's necessary for the switchover from the prod-deploy user account to the jenkins-deploy service account.

Issue: INFRA-10547

## Test plan:
n/a