### PR TITLE
Have alertlib post via a new slack-app.

### DIFF
--- a/vars/withSecrets.groovy
+++ b/vars/withSecrets.groovy
@@ -18,7 +18,8 @@ def slackAlertlibOnly(Closure body) {
    try {
       def uniqueId = sh(script: "echo \$\$", returnStdout: true).trim();
       sh("mkdir -p decrypted_secrets/slack/");
-      sh("gcloud --project khan-academy secrets versions access latest --secret Slack__API_token_for_alertlib >decrypted_secrets/slack/secrets.py.tmp.${uniqueId}");
+      // It's called "districts_slack_token" but really it's for everyone.
+      sh("gcloud --project khan-academy secrets versions access latest --secret districts_slack_token >decrypted_secrets/slack/secrets.py.tmp.${uniqueId}");
       sh("perl -pli -e 's/^/slack_alertlib_api_token = \"/; s/\$/\"/' decrypted_secrets/slack/secrets.py.tmp.${uniqueId}");
       // Create this file atomically.
       sh("mv -f decrypted_secrets/slack/secrets.py.tmp.${uniqueId} decrypted_secrets/slack/secrets.py");
@@ -74,7 +75,7 @@ def slackAndStackdriverAlertlibOnly(Closure body) {
    try {
       def uniqueId = sh(script: "echo \$\$", returnStdout: true).trim();
       sh("mkdir -p decrypted_secrets/slack_and_stackdriver/");
-      sh("gcloud --project khan-academy secrets versions access latest --secret Slack__API_token_for_alertlib >decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
+      sh("gcloud --project khan-academy secrets versions access latest --secret districts_slack_token >decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
       sh("perl -pli -e 's/^/slack_alertlib_api_token = \"/; s/\$/\"/' decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
       sh("echo google_alertlib_service_account = \\'\\'\\' >>decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
       sh("gcloud --project khan-academy secrets versions access latest --secret google_api_service_account__for_alertlib_ >>decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");


### PR DESCRIPTION
## Summary:
Our jenkins jobs use alertlib to post to slack.  Alertlib uses the
bot-token of a particular slack-app that has permission to post
messages to all our channels.

Yesterday, slack disabled the slack-app we had been telling alertlib
to use, because it used a too-old app API.  But it turns out we have a
new, modern slack-app that can do the same thing!  So we just need to
tell alertlib to use that app instead.  This PR does that.

See https://khanacademy.slack.com/archives/C096UP7D0/p1743628787094999

Issue: https://khanacademy.atlassian.net/browse/INFRA-10596

Test plan:

Fingers crossed, I did try using this token locally and it
successfully posted to slack:
```
% echo testing-dist | env ALERTLIB_SECRETS_DIR=/var/tmp ./alert.py --slack=#bot-testing --icon-emoji=:jenkins: --chat-sender="Yo Yo Ma"
```
Posted to:
https://khanacademy.slack.com/archives/C090KRE5P/p1743654251549339