### PR TITLE
Do not deploy to fastly-khanacademy-compute in deploy-znd.

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -362,7 +362,7 @@ def deploy() {
                jobs["deploy-cron-yaml"] = { deployCronYaml(); };
                break;
 
-           case "fastly-khanacademy-compute":
+            case "fastly-khanacademy-compute":
                // We don't have the ability to deploy to a "staging"
                // fastly-ka-compute service at this time; if we _did_
                // deploy this here it would deploy to prod, where it

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -364,8 +364,12 @@ def deploy() {
 
            case "fastly-khanacademy-compute":
                // We don't have the ability to deploy to a "staging"
-               // fastly-ka-compute service at this time, so we just
-               // refuse to deploy at all.
+               // fastly-ka-compute service at this time; if we _did_
+               // deploy this here it would deploy to prod, where it
+               // would just sit there, ignored.  (At least, I _hope_
+               // we would never call set-default on it!)  That's
+               // a waste of time and space, so let's just skip the
+               // deploy.
                echo("WARNING: not deploying to fastly-ka-compute, we don't support znds for that service");
                break;
 

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -362,6 +362,13 @@ def deploy() {
                jobs["deploy-cron-yaml"] = { deployCronYaml(); };
                break;
 
+           case "fastly-khanacademy-compute":
+               // We don't have the ability to deploy to a "staging"
+               // fastly-ka-compute service at this time, so we just
+               // refuse to deploy at all.
+               echo("WARNING: not deploying to fastly-ka-compute, we don't support znds for that service");
+               break;
+
             default:
                // We need to define a new variable so that we don't
                // pass the loop variable into the closure: it may have


### PR DESCRIPTION
## Summary:
Now that fastly-ka-compute is deployed like any other service, the
deploy-znd is very happy to deploy it.  But we can't deploy a znd of
our fastly services!  At least not yet.  Let's specifically skip it.

This isn't strictly necessary: while deploy-znd deploys the fastly
service, it never calls set-default on it, so the deployment doesn't
do anything; it just sits there.  But it's wasted resources to build
it and then have it sit on fastly's servers, never to be used.

I don't know if it's better to just skip it and continue deploying, or
to fail the deploy.  For now I do the former; I think this situation
will most likely arise when someone is editing 'pkg' and selects
"AUTO" for services, in which case they weren't expecting to update
fastly as part of their znd deploy in any case.  People actually
working on fastly-compute probably know better than to try to use
deploy-znd to deploy their changes for testing.

Issue: https://khanacademy.slack.com/archives/CCCC6HZ4K/p1743720351075189

## Test plan:
Fingers crossed

Subscribers: @dbraley