### PR TITLE
Decrypt stackdriver secrets for rollback.

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -878,7 +878,8 @@ def finishWithFailure(why) {
          _alert(alertMsgs.ROLLING_BACK,
                 [rollbackToAsVersion: rollbackToAsVersion,
                  gitTag: GIT_TAG]);
-         withSecrets.slackAlertlibOnly() {  // rollback.py sends to slack
+         // rollback.py sends to slack and also to stackdriver for monitoring.
+         withSecrets.slackAndStackdriverAlertlibOnly() {
             dir("webapp") {
                // During the rollback, we need the local version of code to be
                // of the good version for some of the rollback operation

--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -114,7 +114,8 @@ def verifyValidTag(tag) {
 
 def doRollback() {
    withTimeout('30m') {
-      withSecrets.slackAlertlibOnly() {  // rollback.py talks to slack
+      // rollback.py sends to slack and also to stackdriver for monitoring.
+      withSecrets.slackAndStackdriverAlertlibOnly() {
          cmd = ["deploy/rollback.py"];
          if (params.DRY_RUN) {
             cmd += ["-n"];


### PR DESCRIPTION
## Summary:
When we change the default version of our backend services, we tell
slack, but we also tell stackdriver so we have monitorable stats about
it.  (Though I'm not sure anyone looks at them, which is good given
what I'm about to say.)  We correctly decrypt the necessary
stackdriver secret during a normal deploy, but forget to do so during
rollback.  This means that none of our rollback activity has been
recorded in stackdriver for probably a year now.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1744158543865099?thread_ts=1744157711.877779&cid=C096UP7D0

## Test plan:
Fingers crossed