### PR TITLE
Decrease build-webapp timeout to 1h

### DIFF
--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -922,7 +922,7 @@ def finishWithFailure(why) {
 
 // We do promotes on master, to ease debugging and such.  Promote isn't
 // CPU-bound, and we can have only one at a time, so it's not a problem.
-onMaster('4h') {
+onMaster('1h') {
    notify([slack: [channel: '#1s-and-0s-deploys',
                    sender: 'Mr Monkey',
                    emoji: ':monkey_face:',


### PR DESCRIPTION
## Summary:
[See here for context](https://khanacademy.slack.com/archives/C096UP7D0/p1744668267796409). build-webapp keeps hanging, presumably due to memory issues. Let's decrease the timeout to catch unattended deploys a bit sooner
Issue: INFRA-XXXX

## Test plan: