### PR TITLE
Run static build and deploy by itself

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -529,8 +529,7 @@ def deployToService(service) {
 // This should be called from within a node().
 def deployAndReport() {
    if (SERVICES) {
-      def jobs = ["deploy-to-gcs": { deployToGCS(); },
-                  "deploy-to-gateway-config": { deployToGatewayConfig(); },
+      def jobs = ["deploy-to-gateway-config": { deployToGatewayConfig(); },
                   "deploy-index-yaml": { deployIndexYaml(); },
                   "deploy-queue-yaml": { deployQueueYaml(); },
                   "deploy-pubsub-yaml": { deployPubsubYaml(); },
@@ -552,6 +551,12 @@ def deployAndReport() {
          }
       }
       parallel(jobs);
+
+      // Run static build and deploy by itself. This is to avoid intermittent
+      // OOM issues during the rspack i18n build.
+      parallel([
+         "deploy-to-gcs": { deployToGCS(); }
+      ])
 
       parallel([
          "update-graphql-safelist": { uploadGraphqlSafelist(); }


### PR DESCRIPTION
## Summary:
We are seeing rspack hang at this point:

```
13:47:58  > [3/4] Optimize modules
13:47:58  	[70%] sealing - finish modules
```

https://jenkins.khanacademy.org/job/deploy/job/build-webapp/62204/console

In previous investigations, this was determined to be caused by running
out of memory. Bumping the memory for the node process fixed this for
local dev. We tried bumping this even higher for jenkins but saw little
to no reduction in intermittent hanging builds.

https://github.com/Khan/webapp/pull/31069

This node process is competing for memory with all the other service
deploys currently run in parallel. Change static build and deploy to run
by itself to avoid the node process running out of memory. If folks are
separating their front and back end deploys, this shouldn't slow down
builds.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1744672548072849?thread_ts=1744668267.796409&cid=C096UP7D0

## Test plan:
No guarunteed repro case. Merge and monitor build-webapp job.