### PR TITLE
fix(update-ownership-data,update-devserver-static-images): remove success messages from slack alerts to reduce slack noise

### DIFF
--- a/jobs/update-devserver-static-images.groovy
+++ b/jobs/update-devserver-static-images.groovy
@@ -39,7 +39,7 @@ the updated data-file to it.""",
 ).addStringParam(
    "SLACK_CHANNEL",
    "The slack channel to send our status info.",
-   "#infrastructure"
+   "#local-devserver"
 
 ).addCronSchedule(
    '0 22 * * *'
@@ -95,10 +95,9 @@ def publishResults() {
 // https://khanacademy.slack.com/archives/C096UP7D0/p1738681917185069
 onWorker('build-worker', '10h') {
    notify([slack: [channel: params.SLACK_CHANNEL,
-                   failureChannel: "#local-devserver",
                    sender: 'Devserver Duck',
                    emoji: ':duck:',
-                   when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
+                   when: ['BACK TO NORMAL', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Setup webapp") {
          _setupWebapp();
       }

--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -86,7 +86,7 @@ onMaster('2h') {
                    failureChannel: "#infrastructure-platform",
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
-                   when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
+                   when: ['BACK TO NORMAL', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Initializing webapp") {
          _setupWebapp();
       }


### PR DESCRIPTION
## Summary:
These success messages account for nearly 14% of the messages in #infrastructure for the last year. I think we only really care about when they fail and that they return to normal. Ive adjusted the when conditions to mimic the same behavior as "failureChannel" and removed failureChannel where it was redundant

Issue: https://khanacademy.atlassian.net/wiki/spaces/~712020c9d02fe34fc6401588cedd4b2aaa0680/pages/3960045676/2025+Alerts+Audit

## Test plan:
- look for success messages to be removed from slack