### PR TITLE
[🔥AUDIT🔥] Change the slack emoji for update-ownership-data.

### DIFF
--- a/jobs/update-ownership-data.groovy
+++ b/jobs/update-ownership-data.groovy
@@ -84,8 +84,8 @@ def publishResults() {
 onMaster('2h') {
    notify([slack: [channel: params.SLACK_CHANNEL,
                    failureChannel: "#infrastructure-platform",
-                   sender: 'Testing Turtle',
-                   emoji: ':turtle:',
+                   sender: 'Ownership Octopus',
+                   emoji: ':octopus:',
                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {
       stage("Initializing webapp") {
          _setupWebapp();


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The ownership job is not a testing job, Testing Turtle is not
responsible for it!  Meet our newest emoji, Ownership Octopus.

Issue: none

## Test plan:
None