### PR TITLE
[🔥AUDIT🔥] Rename districts_slack_secret to alertlib_slack_secret.

### DIFF
--- a/vars/withSecrets.groovy
+++ b/vars/withSecrets.groovy
@@ -18,8 +18,7 @@ def slackAlertlibOnly(Closure body) {
    try {
       def uniqueId = sh(script: "echo \$\$", returnStdout: true).trim();
       sh("mkdir -p decrypted_secrets/slack/");
-      // It's called "districts_slack_token" but really it's for everyone.
-      sh("gcloud --project khan-academy secrets versions access latest --secret districts_slack_token >decrypted_secrets/slack/secrets.py.tmp.${uniqueId}");
+      sh("gcloud --project khan-academy secrets versions access latest --secret Slack__API_token_for_alertlib >decrypted_secrets/slack/secrets.py.tmp.${uniqueId}");
       sh("perl -pli -e 's/^/slack_alertlib_api_token = \"/; s/\$/\"/' decrypted_secrets/slack/secrets.py.tmp.${uniqueId}");
       // Create this file atomically.
       sh("mv -f decrypted_secrets/slack/secrets.py.tmp.${uniqueId} decrypted_secrets/slack/secrets.py");
@@ -75,7 +74,7 @@ def slackAndStackdriverAlertlibOnly(Closure body) {
    try {
       def uniqueId = sh(script: "echo \$\$", returnStdout: true).trim();
       sh("mkdir -p decrypted_secrets/slack_and_stackdriver/");
-      sh("gcloud --project khan-academy secrets versions access latest --secret districts_slack_token >decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
+      sh("gcloud --project khan-academy secrets versions access latest --secret Slack__API_token_for_alertlib >decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
       sh("perl -pli -e 's/^/slack_alertlib_api_token = \"/; s/\$/\"/' decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
       sh("echo google_alertlib_service_account = \\'\\'\\' >>decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");
       sh("gcloud --project khan-academy secrets versions access latest --secret google_api_service_account__for_alertlib_ >>decrypted_secrets/slack_and_stackdriver/secrets.py.tmp.${uniqueId}");


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
They both have the same value, but the new name is more desciptive.

Issue: https://github.com/Khan/aws-config/pull/149#discussion_r2059178438

## Test plan:
I used "replay" to deploy to fastly-test with this new withSecrets code:
   https://jenkins.khanacademy.org/job/deploy/job/deploy-fastly/2563/console