### PR TITLE
Update the graphql safelist when we deploy znds

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -272,7 +272,7 @@ def uploadGraphqlSafelist() {
       dir("webapp") {
          exec([
             "deploy/upload_graphql_safelist.py",
-            NEW_VERSION,
+            VERSION,
             "--prod",
          ])
       }

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -256,6 +256,29 @@ def deployToGatewayConfig() {
    }
 }
 
+// Updates the safelist so that znds with changes to queries can make our
+// secutiry/permissions checks happy.
+//
+// We do not however, prime the queryplan caches for znds.  Most often folks
+// creating znds need to access a small number of queries so queryplan priming
+// can be left as a dynamic thing the graphql gateway does for znds.
+def uploadGraphqlSafelist() {
+   // We don't upload queries from the static service here becuase
+   // services/static/deploy/deploy.js is responsible for that.
+   // TODO(kevinb): update deploy scripts for each service to be responsible
+   // for uploading its own queries to the safelist.
+   if (SERVICES.any { it != 'static'}) {
+      echo("Uploading GraphQL queries to the safelist.");
+      dir("webapp") {
+         exec([
+            "deploy/upload_graphql_safelist.py",
+            NEW_VERSION,
+            "--prod",
+         ])
+      }
+   }
+}
+
 // TODO(colin): these messaging functions are mostly duplicated from
 // deploy-webapp.groovy and deploy-history.groovy.  We should probably set up
 // an alertlib (or perhaps just slack messaging) wrapper, since similar
@@ -387,6 +410,10 @@ def deploy() {
       jobs["failFast"] = true;
 
       parallel(jobs);
+
+      parallel([
+         "update-graphql-safelist": { uploadGraphqlSafelist(); }
+      ])
 
       _sendSimpleInterpolatedMessage(
          alertMsgs.JUST_DEPLOYED.text,


### PR DESCRIPTION
## Summary:
We are having an issue where updates to queries in from manually created znds are failing to pass our safelisting checks in the graphql gateway, which causes requests from znds to fail.  This regressed when we updated how we check for permissions of safelisted queries some time ago.

So in this PR I am making sure that we are adding queries from znds that engineers create themselves via jenkins. What Im not doing however, is priming queryplanner caches since these types of znds usually don't need to pre create all the queryplans as engineers tend to use a small subset of the UI.

I found this when I was testing adding the x-trace header to tasks we queue from our backends, which can be seen here https://cloudlogging.app.goo.gl/sHnpaBj8Fke8myCp7.

Issue: INFRA-10640 https://github.com/Khan/webapp/pull/31675#issuecomment-2828916672

## Test plan:
Once these changes are done, deploy a znd with a changed opname and verify that works.