### PR TITLE
Set WORKERS_RAISING_EXCEPTIONS var in e2e-test.groovy

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -168,6 +168,7 @@ SKIPPED_STASH_ID = "e2e-skipped-list";
 WORKER_TYPE = 'ka-test-ec2';
 
 // Used to tell whether all the test-workers raised an exception.
+WORKERS_RAISING_EXCEPTIONS = 0;
 public class TestFailed extends Exception {}
 
 def swallowExceptions(Closure body, Closure onException = {}) {


### PR DESCRIPTION
## Summary:
We're seeing e2e test failures caused by an exception being raised when trying to increment this value. This is presumably happening becuase e2e tests are raising an exception, but it's being swallowed by this one. Let's go ahead and fix this error so we can see what's actually causing the failures.

This var is initialized to 0 in [webapp-test](https://github.com/Khan/jenkins-jobs/blob/40ded7c23c69ae9a87330171d400f8f7f1d17137/jobs/webapp-test.groovy#L144), so let's do the same here.

https://khanacademy.slack.com/archives/C096UP7D0/p1746548190970789
https://khanacademy.slack.com/archives/C096UP7D0/p1746547934277619

Issue: INFRA-10649

## Test plan:
Run as a replay of this job: https://jenkins.khanacademy.org/job/deploy/job/e2e-test/75166