### PR TITLE
Use a new, more reliable, script for updating the caniuse node deps.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -321,11 +321,11 @@ update_caniuse() {
     #    https://github.com/facebook/create-react-app/issues/6708#issuecomment-488392836
     (
         cd webapp
-        for d in `git grep -l caniuse-lite "*yarn.lock" "*pnpm-lock.yaml" | xargs -n1 dirname`; do
+        for d in `git grep -l caniuse-lite "*pnpm-lock.yaml" | xargs -n1 dirname`; do
             (
                 cd "$d"
                 # Use the official tool to update the browserslist and caniuse-lite packages.
-                npx update-browserslist-db@latest
+                pnpm up caniuse-lite --no-save
             )
         done
     )


### PR DESCRIPTION
## Summary:
The old method updated package.json.  Worse, it updated packages
unrelated to caniuse, which is scary to do in an automated fashion.
We tried to fix this in https://github.com/Khan/webapp/pull/30986 but
it looks like that fix wasn't sufficient.  Luckily, @jeresig found a
different fix!

Issue: https://khanacademy.slack.com/archives/CEA6W0F6F/p1747670426392169

## Test plan:
I ran the script manually:
```
for d in `git grep -l caniuse-lite "*pnpm-lock.yaml" | xargs -n1 dirname`; do
    (
        cd "$d"
        # Use the official tool to update the browserslist and caniuse-lite packages.
        pnpm up caniuse-lite --no-save
    )
done
```
I then ran `git status` and saw only pnpm-lock.yaml files were modified.

I ran `git diff` and saw that for many repos, only the caniuse entries
were modified in the lockfile.  But in some repos, there were other
modifications, e.g. in services/static/pnpm-lock.yaml I saw:
```
-  electron-to-chromium@1.5.152:
-    resolution: {integrity: sha512-xBOfg/EBaIlVsHipHl2VdTPJRSvErNUaqW8ejTq5OlOlIYx1wOllCHsAvAIrr55jD1IYEfdR86miUEt8H5IeJg==}
+  electron-to-chromium@1.5.155:
+    resolution: {integrity: sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==}

+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiy
YEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true

-      '@types/qs': 6.9.18
+      '@types/qs': 6.14.0
```
(among other changes.)  services/perseus had even more non-caniuse
changes, while services like services/queryplanner had no extraneous
changes at all.  I am hoping these changes aren't a problem.

Subscribers: @Khan/infra-platform