### PR TITLE
Fix resolveCommitish to work on ambiguous refs.

### DIFF
--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -53,7 +53,16 @@ def resolveCommitish(repo, commit) {
       timeout(1) {
          def lsRemoteOutput = exec.outputOf(["git", "ls-remote", "-q",
                                              repo, commit]);
-         sha1 = lsRemoteOutput.split("\t")[0];
+         // There could be more than one match: e.g. searching for `john`
+         // matches both `refs/head/john` and `refs/head/deploy/john`.
+         // We take the shortest match, which is the most exact match.
+         // TODO(csilvers): verify that the shortest match is actually
+         // what was asked for, if the input is a tag or branch.  Otherwise
+         // if you have two branches named `foo/suffix` and `bar/suffix`
+         // but no branch named `suffix`, this will silently return
+         // `bar/suffix` rather than giving a "branch not found" error.
+         lines = lsRemoteOutput.split("\n").sort { it.size() };
+         sha1 = lines[0].split("\t")[0];
       }
    }
    if (sha1) {


### PR DESCRIPTION
## Summary:
We call resolveCommitish() whenever someone enters a git commit to run
a jenkins job.  It turns a branch or tag into a sha.  But it turns out
the command it uses, `ls-remote` doesn't do exact matches: if you
search for `john` it will return both `refs/head/john` and
`refs/head/deploy/john`.  This has been causing problems where folks
look to deploy one branch and end up deploying a different one.

I fix this here by looking for the *smallest* match.  That is the most
exact one; everything else has another component in it which makes it
a not-exact match.

This isn't perfect, if you had two branches called `foo/suffix` and
`bar/suffix` and tried to deploy `suffix`, it would deploy
`foo/suffix` rather than giving an error that the branch `suffix`
doesn't exist.  But that doesn't happen for us in practice, and in any
case it's better to get something out that fixes the real problems
folks are seeing now.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1748563686088069

## Test plan:
I replayed
https://jenkins.khanacademy.org/job/deploy/job/merge-branches/315749
with this new code and saw that at least it didn't error.