### PR TITLE
[🔥AUDIT🔥] Enable the ability to deploy non master branches to buildmaster

### DIFF
--- a/jobs/deploy-buildmaster.groovy
+++ b/jobs/deploy-buildmaster.groovy
@@ -38,9 +38,9 @@ def buildAndDeploy() {
                            params.GIT_BRANCH);
 
     // Enforce branch restriction: If the branch is not "master", only allow deployment to "khan-test"
-    if (params.GIT_BRANCH != "master" && params.GCLOUD_PROJECT != "khan-test" && params.SERVICE_OR_JOB != "generate-db-migration-scripts") {
-      error("Only 'khan-test' project can be deployed from non-master branches.");
-    }
+    // if (params.GIT_BRANCH != "master" && params.GCLOUD_PROJECT != "khan-test" && params.SERVICE_OR_JOB != "generate-db-migration-scripts") {
+    //   error("Only 'khan-test' project can be deployed from non-master branches.");
+    // }
 
     dir("buildmaster2") {
       withEnv(["GCLOUD_PROJECT=${params.GCLOUD_PROJECT}"]) {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We are working on splitting up the FE code out of the webapp repo and implement its own deploy system.  And we need to be able to deploy to buildmaster from a branch that is not master!  So we are making a change in jenkins to enable that temporarily and we will revert this as soon as we are done this weekend.

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1749233546013349

## Test plan:
we are going to deploy these changes and retry deploying to buildmaster