### PR TITLE
[🔥AUDIT🔥] Fix sorting list of string in jenkins groovy

### DIFF
--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -43,6 +43,16 @@ def checkoutJenkinsTools() {
    }
 }
 
+// Helper function that sorts a list of string by their length.
+// This is needed to correctly figure the branch name from a
+// hash.  See resolveCommitish for more details.
+// https://stackoverflow.com/questions/78348144/how-to-sort-array-with-values-property-in-jenkins-groovy
+// https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/
+@NonCPS  // for list.sort
+def _sortBySize(l) {
+    l.sort { it.size() }
+}
+
 // Turn a commit-ish into a sha1.  If a branch name, we assume the
 // branch exists on the remote and get the sha1 from there.  Otherwise
 // if the input looks like a sha1 we just return it verbatim.
@@ -61,7 +71,7 @@ def resolveCommitish(repo, commit) {
          // if you have two branches named `foo/suffix` and `bar/suffix`
          // but no branch named `suffix`, this will silently return
          // `bar/suffix` rather than giving a "branch not found" error.
-         lines = lsRemoteOutput.split("\n").sort { it.size() };
+         lines = sortBySize(lsRemoteOutput.split("\n"));
          sha1 = lines[0].split("\t")[0];
       }
    }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We fixed an issue previously in https://github.com/Khan/jenkins-jobs/pull/336 where resolving commit hashes to branch names was incorrect.  That PR fixed the underlying issue, but the sorting code is not correct.  It is an issue specifically with groovy in jenkins. The error looks like:

```
	at PluginClassLoader for script-security//org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetArray(SandboxInterceptor.java:482)
	at PluginClassLoader for script-security//org.kohsuke.groovy.sandbox.impl.Checker$11.call(Checker.java:509)
	at PluginClassLoader for script-security//org.kohsuke.groovy.sandbox.impl.Checker.checkedGetArray(Checker.java:514)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getArray(SandboxInvoker.java:45)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.LoggingInvoker.getArray(LoggingInvoker.java:155)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl.ArrayAccessBlock.rawGet(ArrayAccessBlock.java:21)
	at kaGit.resolveCommitish(kaGit.groovy:65)
	at ___cps.transform___(Native Method)
```

This error has to do with CPS code in non CPS transform code. Usually happens when jenkinds groovy code calls into native java code.  More on this mess here https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/.  And this substack post led me to the answer https://stackoverflow.com/questions/78348144/how-to-sort-array-with-values-property-in-jenkins-groovy

Issue: https://khanacademy.atlassian.net/browse/INFRA-10683

## Test plan:
I have manually tested this in a test job where I manually tweaked groovy code until I found a solution.  See here https://jenkins.khanacademy.org/job/deploy/job/stuck-builds/91/console