### PR TITLE
[🔥AUDIT🔥] Fixed _sortBySize function name at call site

### DIFF
--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -71,7 +71,7 @@ def resolveCommitish(repo, commit) {
          // if you have two branches named `foo/suffix` and `bar/suffix`
          // but no branch named `suffix`, this will silently return
          // `bar/suffix` rather than giving a "branch not found" error.
-         lines = sortBySize(lsRemoteOutput.split("\n"));
+         lines = _sortBySize(lsRemoteOutput.split("\n"));
          sha1 = lines[0].split("\t")[0];
       }
    }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I introduced _sortBySize in https://github.com/Khan/jenkins-jobs/pull/338 to fix an issue when we resolve commit hashes from branch names.  But I made a last minute mistake with _sortBySize where the callsite was calling `sortBySize` instead.

```
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: ffd60bcd-3d63-48e7-b029-36053db1c0e4
Also:   	Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: cdbf93fa-cde8-4081-910a-0fe3955f0455
org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
		at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.steps.ParallelStep$ResultHandler$Callback.checkAllDone(ParallelStep.java:151)
		at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.steps.ParallelStep$ResultHandler$Callback.onFailure(ParallelStep.java:138)
		at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:357)
		at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl.ValueBoundContinuation.receive(ValueBoundContinuation.java:21)
java.lang.NoSuchMethodError: No such DSL method 'sortBySize' found among steps [ansiColor, archive, bat, build, catchError, checkout, currentUserGlobalRoles, currentUserItemRoles,
```

Issue: https://khanacademy.atlassian.net/browse/INFRA-10683

## Test plan:
deploy and verify jobs are running again