### PR TITLE
Prime jenkins-jobs for the rename of #1s-and-0s-deploys to #eng-deploys-frontend

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -149,7 +149,7 @@ such as sun.  You can, but need not, include the leading `@`.""",
 ).addStringParam(
    "SLACK_CHANNEL",
    "The slack channel to which to send failure alerts.",
-   "#1s-and-0s-deploys"
+   "#eng-deploys-backend"
 
 ).addStringParam(
    "SLACK_THREAD",

--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -79,7 +79,7 @@ def deleteVersion() {
 }
 
 onMaster('30m') {
-   notify([slack: [channel: '#1s-and-0s-deploys',
+   notify([slack: [channel: '#eng-deploys-backend',
                 sender: 'Mr Monkey',
                 emoji: ':monkey_face:',
                 when: ['FAILURE', 'UNSTABLE', 'ABORTED']]]) {

--- a/jobs/deploy-alert-context.groovy
+++ b/jobs/deploy-alert-context.groovy
@@ -52,7 +52,7 @@ def deploy() {
 
 
 onMaster('2h') {
-   notify([slack: [channel: '#1s-and-0s-deploys',
+   notify([slack: [channel: '#eng-deploys-backend',
                    sender: 'Mr Monkey',
                    emoji: ':monkey_face:',
                    when: ['BUILD START',

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -170,7 +170,7 @@ currentBuild.displayName = ("${currentBuild.displayName} " +
 // the notify() so if there's an error setting them we notify on slack.
 
 // We purposefully hard-code this so people can't do secret deploys. :-)
-SLACK_CHANNEL = "#1s-and-0s-deploys";
+SLACK_CHANNEL = "#eng-deploys-backend";
 
 // The `@<name>` we ping on slack as we go through the deploy.
 DEPLOYER_USERNAME = null;
@@ -924,7 +924,7 @@ def finishWithFailure(why) {
 // We do promotes on master, to ease debugging and such.  Promote isn't
 // CPU-bound, and we can have only one at a time, so it's not a problem.
 onMaster('4h') {
-   notify([slack: [channel: '#1s-and-0s-deploys',
+   notify([slack: [channel: '#eng-deploys-backend',
                    sender: 'Mr Monkey',
                    emoji: ':monkey_face:',
                    // We don't need to notify on start because the buildmaster

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -75,7 +75,7 @@ people will be accessing this deploy.""",
    "SLACK_CHANNEL",
    """The slack channel to which to send failure alerts.  Set to
 @yourusername to send a Slack DM (from Slackbot).""",
-   "#1s-and-0s-deploys"
+   "#eng-deploys-backend"
 
 ).addStringParam(
    "SLACK_THREAD",
@@ -133,7 +133,7 @@ def determineVersion() {
    }
 
    def date = new Date().format("yyMMdd");
-   // Interns and contractors might have a period in their username. 
+   // Interns and contractors might have a period in their username.
    // Since periods are invalid characters, they need to be replaced.
    def user = _currentUser().replace(".", "-");
    // VERSION parameter needs to be lowercased.

--- a/jobs/determine-webapp-services.groovy
+++ b/jobs/determine-webapp-services.groovy
@@ -23,7 +23,7 @@ new Setup(steps
 
 ).addStringParam(
    "BASE_REVISION",
-   """Compute services that would be deployed by the commit since this 
+   """Compute services that would be deployed by the commit since this
    revision based on the the commits between BASE_REVISION..GIT_REVISION.""",
    ""
 
@@ -38,14 +38,14 @@ such as sun.  You can, but need not, include the leading `@`.""",
 ).addStringParam(
    "SLACK_CHANNEL",
    "The slack channel to which to send failure alerts.",
-   "#1s-and-0s-deploys"
+   "#eng-deploys-backend"
 
 ).addStringParam(
    "SLACK_THREAD",
    """The slack thread (must be in SLACK_CHANNEL) to which to send failure
 alerts.  By default we do not send in a thread.  Generally only set by the
 buildmaster, to the 'thread_ts' or 'timestamp' value returned by the Slack
-API.""", 
+API.""",
    ""
 
 ).addStringParam(
@@ -83,8 +83,8 @@ def checkArgs() {
 
 def checkoutWebapp() {
    deployer_username = notify.getDeployerUsername(params.DEPLOYER_USERNAME)
-    
-   // TODO(csilvers): have these return an error message instead of alerting 
+
+   // TODO(csilvers): have these return an error message instead of alerting
    // themselves, so we can use notify.fail().
    withEnv(["SLACK_CHANNEL=${params.SLACK_CHANNEL}",
             "SLACK_THREAD=${params.SLACK_THREAD}",
@@ -116,12 +116,12 @@ def determineServicesToDeploy() {
                            'by setting services on your deploy; ' +
                            "see ${env.BUILD_URL}rebuild for " +
                            'documentation, and `sun: help flags` ' +
-                           "for how to set it. If you aren't sure, " + 
+                           "for how to set it. If you aren't sure, " +
                            'ask deploy-support for help!');
             }
 
             if (services == [""]) {
-               // The above could be [""] if we should deploy nothing. We want 
+               // The above could be [""] if we should deploy nothing. We want
                // to use [] instead of [""].
                services = [];
             }
@@ -134,7 +134,7 @@ def determineServicesToDeploy() {
 }
 
 
-// We use a build worker, because this is a CPU-heavy job and want to run 
+// We use a build worker, because this is a CPU-heavy job and want to run
 // several at a time.
 onWorker('build-worker', '1h') {
    notify([slack: [channel: params.SLACK_CHANNEL,

--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -47,7 +47,7 @@ new Setup(steps
 ).addStringParam(
    "SLACK_CHANNEL",
    "The slack channel to which to send failure alerts.",
-   "#1s-and-0s-deploys"
+   "#eng-deploys-backend"
 
 ).addStringParam(
    "SLACK_THREAD",

--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -8,7 +8,7 @@
 // even while a deploy is going on.
 //
 // You can run this from slack by saying <code>sun: emergency rollback</code>
-// in the <code>1s-and-0s-deploys</code> channel.</p>
+// in the <code>eng-deploys-backend</code> channel.</p>
 
 @Library("kautils")
 
@@ -66,7 +66,7 @@ if (params.DRY_RUN) {
 
 
 // We purposefully hard-code this so people can't do secret deploys. :-)
-SLACK_CHANNEL = "#1s-and-0s-deploys";
+SLACK_CHANNEL = "#eng-deploys-backend";
 
 
 def _alert(def msg) {
@@ -144,7 +144,7 @@ def doRollback() {
 
 
 onMaster('1h') {
-   notify([slack: [channel: '#1s-and-0s-deploys',
+   notify([slack: [channel: '#eng-deploys-backend',
                    failureChannel: '#infrastructure-platform',
                    sender: 'Mr Monkey',
                    emoji: ':monkey_face:',
@@ -164,7 +164,7 @@ onMaster('1h') {
    if (!params.DRY_RUN) {
       build(job: '../deploy/e2e-test',
             parameters: [
-               string(name: 'SLACK_CHANNEL', value: "#1s-and-0s-deploys"),
+               string(name: 'SLACK_CHANNEL', value: "#eng-deploys-backend"),
                string(name: 'TEST_TYPE', value: "deploy"),
             ]);
    } else {

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -34,7 +34,7 @@ create.""",
 ).addStringParam(
    "SLACK_CHANNEL",
    "The slack channel to which to send failure alerts.",
-   "#1s-and-0s-deploys"
+   "#eng-deploys-backend"
 
 ).addStringParam(
    "SLACK_THREAD",

--- a/jobs/notify-znd-owners.groovy
+++ b/jobs/notify-znd-owners.groovy
@@ -45,7 +45,7 @@ def runScript() {
 
 
 onMaster('1h') {
-   notify([slack: [channel: '#1s-and-0s-deploys',
+   notify([slack: [channel: '#eng-deploys-backend',
                    sender: 'Mr Monkey',
                    emoji: ':monkey_face:',
                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']]]) {

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -55,7 +55,7 @@ If the empty string, run *all* tests.""",
 ).addStringParam(
    "SLACK_CHANNEL",
    "The slack channel to which to send failure alerts.",
-   "#1s-and-0s-deploys"
+   "#eng-deploys-backend"
 
 ).addStringParam(
    "SLACK_THREAD",


### PR DESCRIPTION
## Summary:
See the Slack conversation here: https://khanacademy.slack.com/archives/C06P903SXV3/p1746654728788099

This just primes the code for an eventual rename of the channel in Slack. In this repo, it seems to be mostly comments and test data.

Related PRs:
- https://github.com/Khan/buildmaster2/pull/338
- https://github.com/Khan/webapp/pull/33873 
- https://github.com/Khan/jenkins-jobs/pull/340 👈 you are here
- https://github.com/Khan/sre-incident/pull/53
- https://github.com/Khan/alert-router/pull/31
- https://github.com/Khan/internal-webserver/pull/73
- (more PRs in other repos coming...)

Issue: FEI-6727

Driver: lilli@khanacademy.org

## Test plan:
- Not sure yet how to test and deploy this