### PR TITLE
Have deploy-znd work if a username has non-alnums in it.

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -133,9 +133,10 @@ def determineVersion() {
    }
 
    def date = new Date().format("yyMMdd");
-   // Interns and contractors might have a period in their username. 
-   // Since periods are invalid characters, they need to be replaced.
-   def user = _currentUser().replace(".", "-");
+   // Interns and contractors might non-alnums in their username.
+   // Make sure the username consists only of lowercase letters,
+   // numbers, and hyphens, just like we constrain VERSION.
+   def user = _currentUser().toLowerCase().replaceAll(/[^a-z0-9-]/, "-");
    // VERSION parameter needs to be lowercased.
    // Otherwise Fastly will have issue looking up the static version as it expects
    // lowercase hostname.


### PR DESCRIPTION
## Summary:
We have a new employee whose usename includes an underscore, and they
couldn't deploy a znd because the version-name we constructed, which
includes their username, had an underscore and google doesn't like
that.

We already had code to handle periods in usernames, this PR extends
that to all "bad" hostname characters.

Issue: https://khanacademy.slack.com/archives/CDHPTMSTB/p1750190468735759

## Test plan:
I ran this new code manually via `replay` at
   https://jenkins.khanacademy.org/job/deploy/job/deploy-znd/11390/console
just far enough to have it run my changed code.  And it emitted:
```
Failure message: Version: znd-250708-csilvers-strk
```
which shows it's calculating the version correctly still!

Subscribers: @johnyojohn