### PR TITLE
Use `input` instead of a deploy param, to control deploying to production.

### DIFF
--- a/jobs/build-and-deploy-publish-worker.groovy
+++ b/jobs/build-and-deploy-publish-worker.groovy
@@ -33,11 +33,6 @@ WITH CAUTION!</b> -- only for situations where you are overwriting
 someone else's publish-deploy on purpose.""",
     true
 
-).addBooleanParam(
-    "DEPLOY_TO_PROD",
-    """If set, actually deploy the new publish-worker image to production. If not set, the job will stop after building the image.""",
-    false
-// TODO(jackz): Consider using input here
 ).addStringParam(
     "DEPLOYER_EMAIL",
     """Your @khanacademy.org email address is required if deploying the newly built publish-worker image to production.""",
@@ -48,7 +43,7 @@ currentBuild.displayName = "${currentBuild.displayName} (${params.GIT_REVISION})
 
 def setupWebapp() {
     withTimeout('1h') {
-        kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", 
+        kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
             params.GIT_REVISION);
     }
 }
@@ -65,10 +60,10 @@ def runScript() {
         echo("For how to use this image, see");
         echo("https://khanacademy.atlassian.net/wiki/spaces/CP/pages/299204611/Publish+Process+Technical+Documentation");
 
-        if (!params.DEPLOY_TO_PROD) {
-            echo("DEPLOY_TO_PROD is not set. Skipping deployment to production.");
-            return;
-        }
+        // If they say 'no' to this, it aborts the rest of the job.
+        // If they say 'yes', then control flow continues.
+        input("Deploy to production?");
+
         def matcher = (buildOutput =~ /export PUBLISH_VERSION=([\w.-]+)/);
         def publishVersion = matcher ? matcher[0][1] : null;
         matcher = null;


### PR DESCRIPTION
## Summary:
build-and-deploy-publish-worker.groovy has an input parameter to say
whether it does just-build, or build-and-deploy.  This PR changes it
to use an interactive prompt instead, just like we do with
deploy-fastly.groovy.  That way, a user can look at the output of the
build step and decide if it looks good or not, and then say whether to
deploy or not based on that.

Issue: https://github.com/Khan/jenkins-jobs/pull/323#discussion_r2089652443

## Test plan:
Fingers crossed