### PR TITLE
Fix the build-current-sqlite job by syncing the frontend repo.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -40,8 +40,8 @@ def updateDatabase() {
 }
 
 def runScript() {
-   kaGit.safeSyncToOrigin("git@github.com:Khan/webapp",
-                          params.GIT_REVISION);
+   kaGit.safeSyncToOrigin("git@github.com:Khan/webapp", params.GIT_REVISION);
+   kaGit.safeSyncToOrigin("git@github.com:Khan/frontend", "main");
 
    dir("webapp") {
       // Let's make sure we have a recent version of the datastore first.


### PR DESCRIPTION
## Summary:
Now we need both khan/webapp and khan/frontend to run the local
devserver, which was causing the current-sqlite job to fail since it
only synced webapp.  This fixes that.

To get this to work, I had to manually run:
```
timeout 60m git clone git@github.com:Khan/frontend /var/lib/jenkins/repositories/frontend
```
on jenkins-server as the jenkins user.  The script tried to run it (in
https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1565/console)
but it failed with an EPERM error, I don't know why.

Issue: https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1564/console

## Test plan:
I ran the new commands manually via `replay` at
https://jenkins.khanacademy.org/job/misc/job/build-current-sqlite/1568/console