### PR TITLE
Remove static deploys

### DIFF
--- a/jobs/demo-district-update-pass.groovy
+++ b/jobs/demo-district-update-pass.groovy
@@ -1,5 +1,9 @@
 // Automate monthly change for PL sandbox account passwords
 // https://khanacademy.atlassian.net/browse/DIST-4092
+//
+// TODO(nathanjd): This job is broken due to the removal of services/static. It
+// will need to be updated to interface with the frontend repo instead of webapp
+// so might be better as a GitHub Action.
 
 @Library("kautils")
 // Classes we use, under jenkins-jobs/src/.

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -19,10 +19,6 @@
 //
 // 3. Tell google to make our new version the default-serving version.
 //
-// 2-3b. Alternately to 9 and 10, for a static-only deploy, tell
-//    our existing prod server about the new static content we've
-//    deployed.
-//
 // 4. Run end-to-end tests again on now that our new version is default.
 //    This can catch errors that only occur on a khanacdemy.org domain.
 //
@@ -73,13 +69,8 @@ new Setup(steps
     """<p>A comma-separated list of services we wish to change to the new
 version (see below for options), or the special value "auto", which says to
 choose the services to set-default automatically based on what files have
-changed.  For example, you might specify "users,static" to force setting
-default on both the users service and GCS.</p>
-
-<p>Here some less-obvious service names:</p>
-<ul>
-  <li> <b>static</b>: The static (e.g. browser js) service. </li>
-</ul>
+changed.  For example, you might specify "ai-guide,users" to force setting
+default on both the ai-guide and users services.</p>
 
 <p>You can specify the empty string to do no version-switching, like if you
 just change the Makefile.  (Do not do this lightly!)  You may wonder: why do

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -42,13 +42,14 @@ deploying non-default modules!</i>""",
     "SERVICES",
     """<p>A comma-separated list of services we wish to deploy (see below for
 options), or the special value "auto", which says to choose the services to
-deploy automatically based on what files have changed.  For example, you might
-specify "users,static" to force a full deploy to the users service and GCS.</p>
+deploy automatically based on what files have changed. For example, you might
+specify "ai-guide,users" to force a full deploy to the ai-guide and users 
+services.</p>
 
 <p>Here are some services:</p>
 <ul>
-  <li> <b>static</b>: Upload static (e.g. js) files to GCS. </li>
   <li> <b>donations</b>: webapp's services/donations/. </li>
+  <li> <b>index_yaml</b>: upload index.yaml to GAE. </li>
 </ul> """,
     "auto"
 
@@ -137,9 +138,8 @@ def determineVersion() {
    // Make sure the username consists only of lowercase letters,
    // numbers, and hyphens, just like we constrain VERSION.
    def user = _currentUser().toLowerCase().replaceAll(/[^a-z0-9-]/, "-");
-   // VERSION parameter needs to be lowercased.
-   // Otherwise Fastly will have issue looking up the static version as it expects
-   // lowercase hostname.
+   // VERSION parameter needs to be lowercased. Otherwise Fastly will have issue
+   // looking up the static version as it expects lowercase hostname.
    VERSION = "znd-${date}-${user}-${params.VERSION}".toLowerCase();
 
    // DNS has a limit of 63 bytes per hostname-component.  This
@@ -156,25 +156,6 @@ def determineVersion() {
    if ("${VERSION}-dot-progress-reports-dot-khan-academy".length() > 63) {
       notify.fail("Your version-name is too long for DNS! " +
                   "Pick a shorter VERSION");
-   }
-}
-
-// This should be called from within a node().
-def deployToGCS() {
-   // We always "deploy" to gcs, even for python-only deploys, though
-   // for python-only deploys the gcs-deploy is very simple.
-   def args = ["deploy/deploy_to_gcs.py", VERSION,
-               "--slack-channel=${params.SLACK_CHANNEL}",
-               "--deployer-username=@${_currentUser()}"];
-   args += params.SLACK_THREAD ? ["--slack-thread=${params.SLACK_THREAD}"] : [];
-   if (!("static" in SERVICES)) {
-      args += ["--copy-from=default"];
-   }
-
-   withSecrets.slackAlertlibOnly() {  // Because we set --slack-channel
-      dir("webapp") {
-         exec(args)
-      }
    }
 }
 
@@ -246,9 +227,8 @@ def deployCronYaml() {
 // stored on GCS.
 //
 // We only _really_ need to do this if the schema changed, so we could skip it
-// for static deploys or for service deploys that don't change the schema, but
-// uploading the schema here takes less than a second, so it doesn't hurt to
-// just do it always.
+// for service deploys that don't change the schema, but uploading the schema
+// here takes less than a second, so it doesn't hurt to just do it always.
 def deployToGatewayConfig() {
    dir("webapp") {
        exec(["make", "-C", "services/queryplanner",
@@ -264,11 +244,11 @@ def deployToGatewayConfig() {
 // creating znds need to access a small number of queries so queryplan priming
 // can be left as a dynamic thing the graphql gateway does for znds.
 def uploadGraphqlSafelist() {
-   // We don't upload queries from the static service here becuase
-   // services/static/deploy/deploy.js is responsible for that.
+   // We don't upload queries from the frontend apps because their deployments
+   // are handled by the frontend repo: https://github.com/Khan/frontend.
    // TODO(kevinb): update deploy scripts for each service to be responsible
    // for uploading its own queries to the safelist.
-   if (SERVICES.any { it != 'static'}) {
+   if (SERVICES.size() >= 1) {
       echo("Uploading GraphQL queries to the safelist.");
       dir("webapp") {
          exec([
@@ -346,29 +326,10 @@ def deploy() {
                            "You can likely work around this by setting " +
                            "SERVICES on your deploy by a comma-separated " +
                            "list of services. For instance: " +
-                           "'static,donations'");
+                           "'ai-guide,donations'");
             }
          } else {
             SERVICES = params.SERVICES.split(",").collect { it.trim() };
-         }
-
-         // If we're deploying static and other services at the same time,
-         // we want to disallow this as we're going to be moving the static
-         // service out of webapp. It can be overridden with the FORCE flag.
-         if ("static" in SERVICES && SERVICES.size() > 1 && !params.FORCE) {
-            notify.fail("You cannot deploy static and other services at " +
-                        "the same time. Please split apart your backend " +
-                        "and frontend changes into separate deploy branches. " +
-                        "If you must deploy them together, you can use the " +
-                        "'FORCE' flag.");
-         }
-
-         // Make the deps we need based on what we're deploying.  The
-         // python services (default/etc) only need python deps.  The
-         // goliath services build their own deps via their `make deploy`
-         // rules.  That leaves the static service, which needs js deps.
-         if ("static" in SERVICES) {
-             sh("make npm_deps");
          }
       }
 
@@ -377,10 +338,6 @@ def deploy() {
 
       for (service in SERVICES) {
          switch (service) {
-            case "static":
-               jobs["deploy-to-gcs"] = { deployToGCS(); };
-               break;
-
             case "index_yaml":
                jobs["deploy-index-yaml"] = { deployIndexYaml(); };
                break;


### PR DESCRIPTION
## Summary:
The static deploy scripts have already been removed from webapp so
remove the dead code around them.

jobs/demo-district-update-pass should be fixed (likely moved to a GitHub
action in the frontend repo) in a separate PR before it's scheduled to
run again on August 1st.

https://jenkins.khanacademy.org/job/misc/job/demo%20district/job/update-psw/

Issue: https://khanacademy.atlassian.net/browse/INFRA-10711

Test plan:

build-webapp and deploy-znd can be tested with the replay feature.

deploy-webapp will need to be monitored and tested during a real
deployment in #1s-and-0s-deploys. It's too integrated with buildmaster
to be tested independently. I will be blocking the deploy queue during
this time.