### PR TITLE
Make buildmaster update message more clear

### DIFF
--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -124,7 +124,8 @@ def notifyStatus(job, result, sha1) {
 }
 
 def notifyMergeResult(commitId, result, sha1, gae_version_name) {
-   echo("Marking commit #${commitId} as ${result}: ${sha1}");
+   String shaToLog = sha1 ? sha1 : "No merged SHA"
+   echo("Marking buildmaster commit #${commitId} as ${result}: ${shaToLog}");
    def params = [
       commit_id: commitId,
       result: result,


### PR DESCRIPTION
## Summary:
Some folks have been getting confused by the following message in the
merge-branches job logs:

```
17:22:43  Marking commit #12345 as failed: null
```

This leads users to think this is an error message with a null reason as
opposed to what it actually is: a log of the status update we're sending
to buildmaster.

This happens whenever merge-branches encounters a failure, such as a
merge conflict or, in the reported case, when an commit-ish was passed
that doesn't exist in origin. The actual error message exists at the
bottom of the console logs and in the pipeline steps view next to the
red (X).

Change this message to:

```
17:53:27  Marking buildmaster commit #12345 as failed: No merged SHA
```

Issue: https://khanacademy.atlassian.net/browse/INFRA-10684

Test plan:

Tested with the replay feature:

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/324339/console