### PR TITLE
Find exact match for commit-ish, preferring branches over tags

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -25,7 +25,8 @@ new Setup(steps
     """<b>REQUIRED</b>. Usually: the name of a branch to deploy.  Also possible:
 a commit-sha1 to deploy, or a tag like phabricator/diff/&lt;id&gt; (using the latest ID
 from the diff's "history" tab or <code>revisionid-to-diffid.sh D#####</code>).
-Basically, this is passed to <code>git checkout GIT_REVISION</code>.""",
+Basically, this is passed to <code>git checkout GIT_REVISION</code>. Branches 
+will be preferred over tags with the same name.""",
     ""
 
 ).addStringParam(

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -22,7 +22,8 @@ new Setup(steps
 ).addStringParam(
    "GIT_REVISIONS",
    """<b>REQUIRED</b>. A plus-separated list of commit-ishes to merge, like
-"master + yourbranch + mybranch + sometag + deadbeef1234".""",
+"master + yourbranch + mybranch + sometag + deadbeef1234". Branches will be 
+preferred over tags with the same name.""",
    ""
 
 ).addStringParam(

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -136,7 +136,7 @@ String resolveCommitish(String repo, String committish) {
          // No branch or tag found. If this looks like a sha1 hash already, see
          // if it exists as a commit hash in origin.
          if (committish ==~ /[0-9a-fA-F]{5,}/) {
-            echo ("'${committish}' looks like a commit hash, " +
+            echo("'${committish}' looks like a commit hash, " +
                   "checking for it in origin.")
             Integer exitCode = sh(script: "git fetch origin ${committish}", 
                                   returnStatus: true);


### PR DESCRIPTION
## Summary:
Once developers started using `deploy/foo` as well as `foo` for branch
names, we found that the ls-remote logic was incorrectly returning
`deploy/foo` for `foo` when the name occured alphabetically after
`deploy`. We fixed that with the following PRs:

- https://github.com/Khan/jenkins-jobs/pull/336
- https://github.com/Khan/jenkins-jobs/pull/338
- https://github.com/Khan/jenkins-jobs/pull/339

However, we ran into a case where the new logic falls short. Here the
merge-branches job ended up picking `refs/tags/dbraley` over
`ref/heads/dbraley` due to being 1 character shorter.

https://khanacademy.slack.com/archives/C096UP7D0/p1753811466320829?thread_ts=1753811081.432949&cid=C096UP7D0

To fix this, only accept branch or tag names that are exact matches to
the commit-ish, preferring branches over tags.

In addition, verify any raw SHA that merge-branches is passed actually
exists in origin.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10722

Test plan:

I've created 2 branches and a tag that all resolve to different commits.

```sh
$ git ls-remote origin nathanjd
```

```
051757d08c45ecda3fbc1d14546970807ad982de	refs/heads/deploy/nathanjd
5c730d75fcc987373268e423c312ebea4713275d	refs/heads/nathanjd
051757d08c45ecda3fbc1d14546970807ad982de	refs/tags/nathanjd
```

Using the replay feature, merge-branches correctly preferred
refs/heads/nathanjd.

```
11:42:30  'nathanjd' is a branch that resolves to 5c730d75fcc987373268e423c312ebea4713275d
```

Parameters (disambiguate):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326481/

```
GIT_REVISIONS
nathanjd
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) + master + automated-commits and the prior deploy (disambiguate)
BUILDMASTER_DEPLOY_ID
54321
```

Parameters (successful merge):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326477

```
GIT_REVISIONS
master + infra-10684-simple-change
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) + master + automated-commits and the prior deploy (no conflict)
BUILDMASTER_DEPLOY_ID
54321
```

Parameters (single commit by hash):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326475/

```
GIT_REVISIONS
7ec3417defa3e94ccea82e34ad34e74686609d50
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) + master + automated-commits and the prior deploy (one revision)
BUILDMASTER_DEPLOY_ID
54321
```