### PR TITLE
Propagate merge-branches errors to slack.

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -300,8 +300,11 @@ def mergeFromMaster() {
       // processes.  We call this function directly instead of relying
       // on the merge-branches job because deploy-znd isn't
       // facilitated by buildmaster.
-      kaGit.mergeBranches("master+" + params.GIT_REVISION, VERSION);
-
+      description = "ZND for git revision: ${params.GIT_REVISION}\n" +
+                    "Version: ${VERSION}\n" +
+                    "URL: https://prod-${VERSION}.khanacademy.org";
+      kaGit.mergeRevisions("master+" + params.GIT_REVISION, VERSION,
+                           description);
       dir("webapp") {
          clean(params.CLEAN);
       }

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -300,9 +300,9 @@ def mergeFromMaster() {
       // processes.  We call this function directly instead of relying
       // on the merge-branches job because deploy-znd isn't
       // facilitated by buildmaster.
-      description = "ZND for git revision: ${params.GIT_REVISION}\n" +
-                    "Version: ${VERSION}\n" +
-                    "URL: https://prod-${VERSION}.khanacademy.org";
+      String description = "ZND for git revision: ${params.GIT_REVISION}\n" +
+                           "Version: ${VERSION}\n" +
+                           "URL: https://prod-${VERSION}.khanacademy.org";
       kaGit.mergeRevisions("master+" + params.GIT_REVISION, VERSION,
                            description);
       dir("webapp") {

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -79,11 +79,11 @@ def checkArgs() {
 }
 
 
-def getGaeVersionName() {
+String getGaeVersionName() {
    dir('webapp') {
-     def gae_version_name = exec.outputOf(["make", "gae_version_name"]);
-     echo("Found gae version name: ${gae_version_name}");
-     return gae_version_name;
+     String gaeVersionName = exec.outputOf(["make", "gae_version_name"]);
+     echo("Found gae version name: ${gaeVersionName}");
+     return gaeVersionName;
    }
 }
 
@@ -98,11 +98,11 @@ onMaster('1h') {
          checkArgs();
          tagName = ("buildmaster-${params.COMMIT_ID}-" +
                      "${new Date().format('yyyyMMdd-HHmmss')}");
-         def sha1 = kaGit.mergeRevisions(params.GIT_REVISIONS, tagName, 
+         String sha1 = kaGit.mergeRevisions(params.GIT_REVISIONS, tagName, 
                                          params.REVISION_DESCRIPTION);
-         def gae_version_name = getGaeVersionName();
+         String gaeVersionName = getGaeVersionName();
          buildmaster.notifyMergeResult(params.COMMIT_ID, 'success',
-                                       sha1, gae_version_name);
+                                       sha1, gaeVersionName);
       } catch (e) {
          // We don't really care about the difference between aborted and failed;
          // we can't use notify because we want somewhat special semantics; and

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -96,9 +96,10 @@ onMaster('1h') {
                    when: ['FAILURE', 'UNSTABLE']]]) {
       try {
          checkArgs();
-         tag_name = ("buildmaster-${params.COMMIT_ID}-" +
+         tagName = ("buildmaster-${params.COMMIT_ID}-" +
                      "${new Date().format('yyyyMMdd-HHmmss')}");
-         def sha1 = kaGit.mergeBranches(params.GIT_REVISIONS, tag_name);
+         def sha1 = kaGit.mergeRevisions(params.GIT_REVISIONS, tagName, 
+                                         params.REVISION_DESCRIPTION);
          def gae_version_name = getGaeVersionName();
          buildmaster.notifyMergeResult(params.COMMIT_ID, 'success',
                                        sha1, gae_version_name);

--- a/vars/exec.groovy
+++ b/vars/exec.groovy
@@ -33,3 +33,38 @@ def outputOf(arglist) {
 def statusOf(arglist) {
    return sh(script: shellEscapeList(arglist), returnStatus: true);
 }
+
+// Result of executing a shell command.
+class ExecResult {
+   // Escaped command that was run.
+   String command
+
+   // Resulting exit code.
+   Integer exitCode
+
+   // Combined output of stdout and stderr.
+   String output
+}
+
+// Execute a list of args as a shell command, then return the exit code, the
+// combined stdout + stderr, and the escaped command that was run.
+ExecResult runCommand(List<String> arglist) {
+   String cmd = shellEscapeList(arglist)
+   // Redirecting cmd stderr to stdout, in order to return it if cmd failed
+   def output = ""
+   def rc = 0
+   withEnv(["RC=0"]) {
+      output = sh(script: """
+         set +x
+         (${cmd}) 2>&1 || RC=\$?
+         echo "EXIT_CODE:\$RC"
+      """, returnStdout: true).trim()
+   }
+   // Extracting exit code from the last line of output
+   def exitCodeMatch = output =~ /(?s)(.*)EXIT_CODE:(\d+)$/
+   if (exitCodeMatch) {
+      rc = exitCodeMatch[0][2].toInteger()
+      output = exitCodeMatch[0][1].trim()
+   }
+   return new ExecResult(exitCode: rc, output: output, command: cmd)
+}

--- a/vars/exec.groovy
+++ b/vars/exec.groovy
@@ -1,3 +1,5 @@
+import java.util.regex.Matcher
+
 def shellEscape(s) {
    // We don't need to do escaping if the string does not contain any
    // characters that are meaningful to the shell.
@@ -51,20 +53,20 @@ class ExecResult {
 ExecResult runCommand(List<String> arglist) {
    String cmd = shellEscapeList(arglist)
    // Redirecting cmd stderr to stdout, in order to return it if cmd failed
-   def output = ""
-   def rc = 0
+   String output = "";
+   Integer rc = 0;
    withEnv(["RC=0"]) {
       output = sh(script: """
          set +x
-         (${cmd}) 2>&1 || RC=\$?
+         ( ${cmd} ) 2>&1 || RC=\$?
          echo "EXIT_CODE:\$RC"
-      """, returnStdout: true).trim()
+      """, returnStdout: true).trim();
    }
    // Extracting exit code from the last line of output
-   def exitCodeMatch = output =~ /(?s)(.*)EXIT_CODE:(\d+)$/
+   Matcher exitCodeMatch = output =~ /(?s)(.*)EXIT_CODE:(\d+)$/;
    if (exitCodeMatch) {
-      rc = exitCodeMatch[0][2].toInteger()
-      output = exitCodeMatch[0][1].trim()
+      rc = exitCodeMatch[0][2].toInteger();
+      output = exitCodeMatch[0][1].trim();
    }
-   return new ExecResult(exitCode: rc, output: output, command: cmd)
+   return new ExecResult(exitCode: rc, output: output, command: cmd);
 }

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -220,7 +220,7 @@ String mergeRevisions(gitRevisions, tagName, description) {
    if (allRevisions.size() == 1) {
       echo("Only one git revision passed, looking up and returning its SHA.")
       String sha1 = resolveCommitish("git@github.com:Khan/webapp", 
-                                  allRevisions[i]);
+                                  allRevisions[0]);
       echo("Resolved ${gitRevisions} --> ${sha1}");
       return sha1;
    }

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -199,19 +199,38 @@ def safeMergeFromMaster(dir, commitToMergeInto, submodules=[]) {
 }
 
 
-// Merges multiple branches together into a single commit.
+// Merge multiple webapp git revisions together and return the resulting commit
+// SHA.
 //
 // Arguments:
-// - gitRevisions: string containing one or more branche names separated by "+"
-// - tagName: string to tag the resulting commit with.  We need to tag the
-//   result of the merge so git doesn't prune it.
+// - gitRevisions: String containing one or more branch name, tag name, or
+//   commit SHA separated by "+".
+// - tagName: String to tag the resulting commit with. We need to tag the result
+//   of the merge so git doesn't prune it.
+// - description: Human-readable description to aid in debugging. Added to new
+//   commit message.
 //
 // Notes:
 // - Used by merge-granches.groovy and deploy-znd.groovy.
-def mergeBranches(gitRevisions, tagName) {
-   def allBranches = gitRevisions.split(/\+/);
-   quickClone("git@github.com:Khan/webapp", "webapp",
-                    allBranches[0].trim());
+String mergeRevisions(gitRevisions, tagName, description) {
+   List<String> allRevisions = gitRevisions.split(/\+/);
+
+   // If there's only one revision, skip checkout and tag, return sha1
+   // immediately.
+   if (allRevisions.size() == 1) {
+      echo("Only one git revision passed, looking up and returning its SHA.")
+      String sha1 = resolveCommitish("git@github.com:Khan/webapp", 
+                                  allRevisions[i]);
+      echo("Resolved ${gitRevisions} --> ${sha1}");
+      return sha1;
+   }
+
+   // Trim passed revisions for consistent ouput formatting.
+   for (Integer i = 0; i < allRevisions.size(); i++) {
+      allRevisions[i] = allRevisions[i].trim();
+   }
+
+   quickClone("git@github.com:Khan/webapp", "webapp", allRevisions[0]);
    dir('webapp') {
       // We need to reset before fetching, because if a previous incomplete
       // merge left .gitmodules in a weird state, git will fail to read its
@@ -220,43 +239,83 @@ def mergeBranches(gitRevisions, tagName) {
       // as you might think.
       exec(["git", "reset", "--hard"]);
    }
+
    // Get rid of all old branches; if they were dangling they'd break fetch.
    exec(["jenkins-jobs/safe_git.sh", "clean_branches", "webapp"]);
    quickFetch("webapp");
+
+   // Do the merge(s)!
    dir('webapp') {
-      for (def i = 0; i < allBranches.size(); i++) {
-         def branchSha1 = resolveCommitish("git@github.com:Khan/webapp",
-                                           allBranches[i].trim());
-         try {
-            if (i == 0) {
-               // TODO(benkraft): If there's only one branch, skip the checkout
-               // and tag/return sha1 immediately.
+      for (Integer i = 0; i < allRevisions.size(); i++) {
+         String branchSha1 = resolveCommitish("git@github.com:Khan/webapp",
+                                              allRevisions[i]);
+         if (i == 0) {
+            // First, checkout the base revision.
+            try {
                // Note that this is a no-op when we did a fresh clone above.
-               exec(["git", "checkout", "-f", branchSha1]);
-            } else {
-               // TODO(benkraft): This puts the sha in the commit message
-               // instead of the branch; we should just write our own commit
-               // message.
-               exec(["git", "merge", branchSha1]);
+               ExecResult result = exec.runCommand([
+                  "git", "checkout", "-f", branchSha1
+               ]);
+               if (result.exitCode != 0) {
+                  echo "Checkout failure command: ${result.command}";
+                  echo "Checkout failure exitCode: ${result.exitCode}";
+                  echo "Checkout failure ouput: ${result.output}";
+                  notify.fail("Failed to checkout ${branchSha1}:\n" +
+                           "${result.output}");
+               }
+            } catch(FailedBuild e) {
+               // Error from git checkout thrown by notify.fail().
+               throw e;
+            } catch (e) {
+               // Error from inability to call git checkout.
+               notify.rethrowIfAborted(e);
+               notify.fail("Failed to call checkout ${branchSha1}: " +
+                           "${e.getMessage()}", e);
             }
-         } catch (e) {
-            notify.rethrowIfAborted(e);
-            // TODO(benkraft): Also send the output of the merge command that
-            // failed.
-            notify.fail("Failed to merge ${branchSha1} into " +
-                        "${allBranches[0..<i].join(' + ')}: ${e}");
+         } else {
+            // Then, merge the next successive revision.
+
+            // Write our own commit message so it's not just the SHA.
+            String previousRevisions = allRevisions[0..<i].join(' + ');
+            String commitMessage = [
+               "Merge '${allRevisions[i]}' into '${previousRevisions}' " +
+                  "for tag '${tagName}'",
+               "",
+               "${description}"
+            ].join("\n");
+
+            try {
+               ExecResult result = exec.runCommand([
+                  "git", "merge", branchSha1, "-m", commitMessage
+               ]);
+               if (result.exitCode != 0) {
+                  echo "Merge failure command: ${result.command}";
+                  echo "Merge failure exitCode: ${result.exitCode}";
+                  echo "Merge failure ouput: ${result.output}";
+                  notify.fail("Failed to merge ${branchSha1} into " +
+                              "${previousRevisions}:\n${result.output}");
+               }
+            } catch(FailedBuild e) {
+               // Error from git merge thrown by notify.fail().
+               throw e;
+            } catch (e) {
+               // Error from inability to call git merge.
+               notify.rethrowIfAborted(e);
+               notify.fail("Failed to call merge ${branchSha1} into " +
+                           "${previousRevisions}: ${e.getMessage()}", e);
+            }
          }
       }
+
       // We need to at least tag the commit, otherwise github may prune it.
-      // (We can skip this step if something already points to the commit; in
-      // fact we want to to avoid Phabricator paying attention to this commit.)
+      // (We can skip this step if something already points to the commit.)
       // These tags ar pruned weekly in weekly-maintenance.sh.
       if (exec.outputOf(["git", "tag", "--points-at", "HEAD"]) == "" &&
           exec.outputOf(["git", "branch", "-r", "--points-at", "HEAD"]) == "") {
          exec(["git", "tag", tagName, "HEAD"]);
          exec(["git", "push", "--tags", "origin"]);
       }
-      def sha1 = exec.outputOf(["git", "rev-parse", "HEAD"]);
+      String sha1 = exec.outputOf(["git", "rev-parse", "HEAD"]);
       echo("Resolved ${gitRevisions} --> ${sha1}");
       return sha1;
    }


### PR DESCRIPTION
## Summary:
Include failure reason and stack trace when sending failure
notifications to slack.

Add sh wrapper that allows collection of stderr, stdout and exit code.

For merge-branches, include the output of the `git checkout` and
`git merge` commands.

This is the start of an ongoing effort to push the reason for Jenkins
job failures to the deployer via slack with a primary goal of reducing
the volume of @deploy-support-backend requests.  Right now, we direct
users to "look for the red circle(s)" in Jenkins which is fraught with
unrelated information that look like errors to anyone without intimate
knowledge of the deploy system. Ideally, users would never need to go to
Jenkins to know why their deployment failed and what actions they need
to take.

Some context on the motivations for doing so can be found in this PR:

https://github.com/Khan/jenkins-jobs/pull/347

With notify.fail() now propagating the reason for failure, we can begin
to instrument the rest of our jobs in the same manner.

Old failure message:

<img width="679" height="227" alt="Screenshot 2025-08-12 at 3 25 06 PM" src="https://github.com/user-attachments/assets/dc9c63dc-2f92-4110-acf9-88cfc64d9aff" />

New failure message (truncated in screenshot, but does include the full stack trace):

<img width="732" height="624" alt="Screenshot 2025-08-12 at 11 08 33 AM" src="https://github.com/user-attachments/assets/5d5472d7-822e-4861-961f-066616a7f5ed" />

Issue: https://khanacademy.atlassian.net/browse/INFRA-10684

## Test plan:

I've tested with the replay feature of the merge-branches job.

Parameters (merge conflict):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/325914/

```
GIT_REVISIONS
master + nathanjd + cp-7339-fix-common-core-ids + d4dcd8794de8e5693a4521c815b760f4106d8994
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) + master + automated-commits and the prior deploy (merge conflict)
BUILDMASTER_DEPLOY_ID
54321
```

Parameters (successful merge):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/325916/

```
GIT_REVISIONS
master + infra-10684-simple-change
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) + master + automated-commits and the prior deploy (no conflict)
BUILDMASTER_DEPLOY_ID
54321
```

Parameters (single revision):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/325918/

```
GIT_REVISIONS
master
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) + master + automated-commits and the prior deploy (one revision)
BUILDMASTER_DEPLOY_ID
54321
```