### PR TITLE
Always perform a checkout during merge-branches

### DIFF
--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -215,16 +215,6 @@ def safeMergeFromMaster(dir, commitToMergeInto, submodules=[]) {
 String mergeRevisions(gitRevisions, tagName, description) {
    List<String> allRevisions = gitRevisions.split(/\+/);
 
-   // If there's only one revision, skip checkout and tag, return sha1
-   // immediately.
-   if (allRevisions.size() == 1) {
-      echo("Only one git revision passed, looking up and returning its SHA.")
-      String sha1 = resolveCommitish("git@github.com:Khan/webapp", 
-                                  allRevisions[0]);
-      echo("Resolved ${gitRevisions} --> ${sha1}");
-      return sha1;
-   }
-
    // Trim passed revisions for consistent ouput formatting.
    for (Integer i = 0; i < allRevisions.size(); i++) {
       allRevisions[i] = allRevisions[i].trim();
@@ -250,7 +240,9 @@ String mergeRevisions(gitRevisions, tagName, description) {
          String branchSha1 = resolveCommitish("git@github.com:Khan/webapp",
                                               allRevisions[i]);
          if (i == 0) {
-            // First, checkout the base revision.
+            // First, checkout the base revision. Even if there aren't
+            // subsequent revisions to merge, we still want the correct revision
+            // checked out after we return.
             try {
                // Note that this is a no-op when we did a fresh clone above.
                ExecResult result = exec.runCommand([


### PR DESCRIPTION
## Summary:
I completed a TODO in https://github.com/Khan/jenkins-jobs/pull/349 to
just have `kaGit.mergeRevisions` return the SHA from ls-remote if there
are actually no merges to perform. But by skipping checkout, 
`make gae_version_name` is generating the name from whatever 
cached version of the repo it had from the last job. This is preventing
the prerequisite merge-branches from successfully reporting back to 
buildmaster due to:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "commit_gae_version_name_key"
```

So, webapp-test is never kicked off for PRs.

https://khanacademy.slack.com/archives/C013ANU53LK/p1755118117498589

Remove this optimization so that, when the merge-branches job calls
`make gae_version_name`, it is run against the correct git revision.

Once this is merged, I will replay all the merge-branches jobs that
failed to report to buildmaster due to this issue.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10737

Test plan:

Replay existing merge-branches job that failed to report to buildmaster
due to this issue.

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326071/console

Tested with replay:

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326086/console

As a result, buildmaster successfully kiced off a webapp-test:

https://jenkins.khanacademy.org/job/deploy/job/webapp-test/308969/