### PR TITLE
Find exact match for commit-ish, preferring branches over tags

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -25,7 +25,8 @@ new Setup(steps
     """<b>REQUIRED</b>. Usually: the name of a branch to deploy.  Also possible:
 a commit-sha1 to deploy, or a tag like phabricator/diff/&lt;id&gt; (using the latest ID
 from the diff's "history" tab or <code>revisionid-to-diffid.sh D#####</code>).
-Basically, this is passed to <code>git checkout GIT_REVISION</code>.""",
+Basically, this is passed to <code>git checkout GIT_REVISION</code>. Branches 
+will be preferred over tags with the same name.""",
     ""
 
 ).addStringParam(

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -22,7 +22,8 @@ new Setup(steps
 ).addStringParam(
    "GIT_REVISIONS",
    """<b>REQUIRED</b>. A plus-separated list of commit-ishes to merge, like
-"master + yourbranch + mybranch + sometag + deadbeef1234".""",
+"master + yourbranch + mybranch + sometag + deadbeef1234". Branches will be 
+preferred over tags with the same name.""",
    ""
 
 ).addStringParam(

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -43,48 +43,118 @@ def checkoutJenkinsTools() {
    }
 }
 
-// Helper function that sorts a list of string by their length.
-// This is needed to correctly figure the branch name from a
-// hash.  See resolveCommitish for more details.
-// https://stackoverflow.com/questions/78348144/how-to-sort-array-with-values-property-in-jenkins-groovy
-// https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/
-@NonCPS  // for list.sort
-def _sortBySize(l) {
-    l.sort { it.size() }
+// Represents a single ref from `git ls-remote ...` command output.
+// https://git-scm.com/book/ms/v2/Git-Internals-Git-References
+class Ref {
+   // Ref name that was returned from ls-remote. Points to hash.
+   String name
+
+   // The commit hash (sha1) this ref points to. Also known as commit ID.
+   String hash
 }
 
-// Turn a commit-ish into a sha1.  If a branch name, we assume the
-// branch exists on the remote and get the sha1 from there.  Otherwise
-// if the input looks like a sha1 we just return it verbatim.
-// Otherwise we error.
-def resolveCommitish(repo, commit) {
-   def sha1 = null;
-   stage("Resolving commit") {
-      timeout(1) {
-         def lsRemoteOutput = exec.outputOf(["git", "ls-remote", "-q",
-                                             repo, commit]);
-         // There could be more than one match: e.g. searching for `john`
-         // matches both `refs/head/john` and `refs/head/deploy/john`.
-         // We take the shortest match, which is the most exact match.
-         // TODO(csilvers): verify that the shortest match is actually
-         // what was asked for, if the input is a tag or branch.  Otherwise
-         // if you have two branches named `foo/suffix` and `bar/suffix`
-         // but no branch named `suffix`, this will silently return
-         // `bar/suffix` rather than giving a "branch not found" error.
-         lines = _sortBySize(lsRemoteOutput.split("\n"));
-         sha1 = lines[0].split("\t")[0];
+String _refNameFromLsRemoteLine(String lsRemoteLine) {
+   return lsRemoteLine.split("\t")[1].trim();
+}
+
+String _commitHashFromLsRemoteLine(String lsRemoteLine) {
+   return lsRemoteLine.split("\t")[0].trim();
+}
+
+// Return each ref that was output by ls-remote for a given commit-ish.
+// ls-remote does not return any results when commit hashes are queried
+// directly.
+//
+// Example output: 
+// $ git ls-remote origin foo
+// 0670bc5a1c0bab364dfb981f7854b6b17bdd49db  refs/heads/deploy/foo
+// df49834270ad034ecf776590908d429a8140c485  refs/heads/foo
+// 2998fe06daa988757b847afd5a99022334b90d4d  refs/tags/foo
+Ref[] lsRemote(String repo, String committish) {
+   // https://git-scm.com/docs/git-ls-remote
+   String lsRemoteOutput = exec.outputOf(["git", "ls-remote", "-q", repo,
+                                          committish]);
+   if (lsRemoteOutput == "") {
+      return [];
+   }
+   
+   return lsRemoteOutput.split("\n").collect {
+      new Ref(hash: _commitHashFromLsRemoteLine(it),
+              name: _refNameFromLsRemoteLine(it));
+   };
+}
+
+// Return commit hash from a ls-remote result if any refs names are an exact
+// match to the branch name. A partial match is not performed here because we
+// don't want to return the hash for `deploy/foo` when the user requested just
+// `foo`.
+String _findCommitHashFromBranchRef(Ref[] refs, String branchName) {
+   Ref found = refs.find { it.name == "refs/heads/${branchName}" }
+   if (found) {
+      return found.hash;
+   }
+   return null;
+}
+
+// Return commit hash from a ls-remote result if any ref names are an exact
+// match to the tag name. A partial match is not performed here because we don't
+// want to return the hash for `deploy/foo` when the user requested just `foo`.
+String _findCommitHashFromTagRef(Ref[] refs, String tagName) {
+   Ref found = refs.find { it.name == "refs/tags/${tagName}" }
+   if (found) {
+      return found.hash;
+   }
+   return null;
+}
+
+// Return a commit ID (sha1 hash) from a commit-ish. If a branch or tag name, we
+// assume the branch exists on the remote and get the hash from there,
+// preferring branches over tags. Otherwise, if the input looks like a hash we
+// check for it in origin before returning it verbatim if it exists. Otherwise,
+// we error.
+// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-commit-ishalsocommittish
+String resolveCommitish(String repo, String committish) {
+   String hash = null
+   stage("Resolving commit-ish") {
+      timeout(time: 1, unit: "HOURS") {
+         Ref[] lsRemoteRefs = lsRemote(repo, committish);
+
+         // First, check for branch as we prefer branches over tags.
+         hash = _findCommitHashFromBranchRef(lsRemoteRefs, committish);
+         if (hash) {
+            echo("'${committish}' is a branch that resolves to ${hash}");
+            return;
+         }
+
+         // No branch found, check for tag.
+         hash = _findCommitHashFromTagRef(lsRemoteRefs, committish);
+         if (hash) {
+            echo("'${committish}' is a tag that resolves to ${hash}");
+            return;
+         }
+
+         // No branch or tag found. If this looks like a sha1 hash already, see
+         // if it exists as a commit hash in origin.
+         if (committish ==~ /[0-9a-fA-F]{5,}/) {
+            echo("'${committish}' looks like a commit hash, " +
+                  "checking for it in origin.")
+            Integer exitCode = sh(script: "git fetch origin ${committish}", 
+                                  returnStatus: true);
+            // A 0 exit code means the commit exists in origin.
+            if (exitCode == 0) {
+               echo("'${committish}' is a commit hash in origin.");
+               hash = committish;
+               return;
+            }
+         }
       }
    }
-   if (sha1) {
-      echo("'${commit}' resolves to ${sha1}");
-      return sha1;
+
+   if (hash) {
+      return hash;
    }
-   // If this looks like a sha1 already, return it.
-   // TODO(csilvers): complain to slack?
-   if (commit ==~ /[0-9a-fA-F]{5,}/) {
-      return commit;
-   }
-   error("Cannot find '${commit}' in repo '${repo}'");
+
+   error("Cannot find '${committish}' in repo '${repo}'");
 }
 
 def _buildTagFile(repo) {

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -108,10 +108,12 @@ String _findCommitHashFromTagRef(Ref[] refs, String tagName) {
 }
 
 // Return a commit ID (sha1 hash) from a commit-ish. If a branch or tag name, we
-// assume the branch exists on the remote and get the hash from there,
-// preferring branches over tags. Otherwise, if the input looks like a hash we
-// check for it in origin before returning it verbatim if it exists. Otherwise,
-// we error.
+// check if it exists on the remote and get the hash from there, preferring
+// branches over tags. Otherwise, if the input looks like a hash we return it
+// verbatim. Otherwise, we error.
+//
+// To be called before checking out the repo to determine which commit to 
+// checkout.
 // https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-commit-ishalsocommittish
 String resolveCommitish(String repo, String committish) {
    String hash = null
@@ -137,15 +139,9 @@ String resolveCommitish(String repo, String committish) {
          // if it exists as a commit hash in origin.
          if (committish ==~ /[0-9a-fA-F]{5,}/) {
             echo("'${committish}' looks like a commit hash, " +
-                  "checking for it in origin.")
-            Integer exitCode = sh(script: "git fetch origin ${committish}", 
-                                  returnStatus: true);
-            // A 0 exit code means the commit exists in origin.
-            if (exitCode == 0) {
-               echo("'${committish}' is a commit hash in origin.");
-               hash = committish;
-               return;
-            }
+                  "assuming it exists in origin.")
+            hash = committish;
+            return;
          }
       }
    }


### PR DESCRIPTION
## Summary:

Second try at this change! The previous attempt
(https://github.com/Khan/jenkins-jobs/pull/348) failed due to webapp-test and
e2e-test jobs calling resolveCommitish before checking out or cloning webapp,
which resulted in an inability to fetch when trying to determine if a specific
commit hash existed in origin. Since all jobs immediately try to checkout the
return value of resolveCommitish, we can rely on the checkout failing to alert
the deployer that the commit does not exist in origin.

Once developers started using `deploy/foo` as well as `foo` for branch
names, we found that the ls-remote logic was incorrectly returning
`deploy/foo` for `foo` when the name occured alphabetically after
`deploy`. We fixed that with the following PRs:

- https://github.com/Khan/jenkins-jobs/pull/336
- https://github.com/Khan/jenkins-jobs/pull/338
- https://github.com/Khan/jenkins-jobs/pull/339

However, we ran into a case where the new logic falls short. Here the
merge-branches job ended up picking `refs/tags/dbraley` over
`ref/heads/dbraley` due to being 1 character shorter.

https://khanacademy.slack.com/archives/C096UP7D0/p1753811466320829?thread_ts=1753811081.432949&cid=C096UP7D0

To fix this, only accept branch or tag names that are exact matches to
the commit-ish, preferring branches over tags.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10722

Test plan:

I've created 2 branches and a tag that all resolve to different commits.

```sh
$ git ls-remote origin nathanjd
```

```
051757d08c45ecda3fbc1d14546970807ad982de	refs/heads/deploy/nathanjd
5c730d75fcc987373268e423c312ebea4713275d	refs/heads/nathanjd
051757d08c45ecda3fbc1d14546970807ad982de	refs/tags/nathanjd
```

Using the replay feature, merge-branches correctly preferred
refs/heads/nathanjd.

```
11:43:39  'nathanjd' is a branch that resolves to 5c730d75fcc987373268e423c312ebea4713275d
```

merge-branches Parameters (disambiguate):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326608/

```
GIT_REVISIONS
nathanjd
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) (disambiguate)
BUILDMASTER_DEPLOY_ID
54321
```

merge-branches Parameters (successful merge):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326612/

```
GIT_REVISIONS
master + infra-10684-simple-change
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) (no conflict)
BUILDMASTER_DEPLOY_ID
54321
```

merge-branches Parameters (single commit by hash):

https://jenkins.khanacademy.org/job/deploy/job/merge-branches/326614/

```
GIT_REVISIONS
7ec3417defa3e94ccea82e34ad34e74686609d50
COMMIT_ID
12345
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

JOB_PRIORITY
6
REVISION_DESCRIPTION
test description (please ignore) (one revision)
BUILDMASTER_DEPLOY_ID
54321
```

webapp-test Parameters:

https://jenkins.khanacademy.org/job/deploy/job/webapp-test/309436/

```
GIT_REVISION
7ec3417defa3e94ccea82e34ad34e74686609d50
BASE_REVISION
origin/master
SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

CLEAN
some
NUM_WORKER_MACHINES
10
CLIENTS_PER_WORKER
2
DEPLOYER_USERNAME
@nathandobrowolski
REVISION_DESCRIPTION
test description (please ignore)
BUILDMASTER_DEPLOY_ID
54321
JOB_PRIORITY
6
```

e2e-test Parameters:

https://jenkins.khanacademy.org/job/deploy/job/e2e-test/79282/

```
URL
https://prod-250820-1119-a3df2c6165b6.khanacademy.org
TEST_TYPE
origin/master
TESTS_TO_RUN

SLACK_CHANNEL
@nathandobrowolski
SLACK_THREAD

NUM_WORKER_MACHINES
30
USE_FIRSTINQUEUE_WORKERS
false
GIT_REVISION
7ec3417defa3e94ccea82e34ad34e74686609d50
DEPLOYER_USERNAME
@nathandobrowolski
REVISION_DESCRIPTION
test description (please ignore)
BUILDMASTER_DEPLOY_ID
54321

SET_SPLIT_COOKIE

EXPECTED_VERSION

EXPECTED_VERSION_SERVICES

JOB_PRIORITY
6

SKIP_TESTS

```