### PR TITLE
Get rid of the SKIP_TESTS parameter in our e2e tests.

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -127,12 +127,6 @@ through 11. See https://jenkins.khanacademy.org/advanced-build-queue/
 for more information.""",
    "6"
 
-).addStringParam(
-   "SKIP_TESTS",
-   """IGNORE: This is a dummy parameter that is only here to avoid breaking the
-   communication with buildmaster""",
-   ""
-
 ).apply();
 
 // Override the build name by the info that is passed in (from buildmaster).


### PR DESCRIPTION
## Summary:
Buildmaster hasn't sent this in a while, we can remove it from the
jenkins side as well.

Issue: https://khanacademy.atlassian.net/browse/INFRA-10563

## Test plan:
Fingers crossed

Subscribers: @Khan/infra-platform