### PR TITLE
Add lockable resource to prevent update-traffic timeout

### DIFF
--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -87,9 +87,31 @@ onMaster('30m') {
       stage("Initializing webapp") {
          _setupWebapp();
       }
-      stage("Deleting") {
-         withVirtualenv.python3() {
-            deleteVersion();
+      // Acquire the shared mutex with deploy-webapp's set default step. If
+      // set default takes a long time, we may get multiple delete-version jobs
+      // queued for the same version(s). This should no-op just fine.
+      //
+      // While we would like to prioritize deploy-webapp over delete-versions by
+      // skipping this job when locked, we also don't want to lose any delete
+      // requests that wouldn't be automatically retried, such as ZND deletion
+      // requests from users. Since GCP support has advised us to keep our
+      // traffic tag count as low as possible, we really don't want to miss any
+      // ZND deletions. Setting lock priority lower than in the set default step
+      // should be a good middle ground.
+      //
+      // https://plugins.jenkins.io/lockable-resources/#plugin-content-lock-queue-priority
+      //
+      // We do this because the update-traffic command creates a
+      // LongRunningOperation that expects a specific target traffic allocation
+      // across all revisions with traffic tags and/or a traffic % higher than
+      // 0%. If a revision is deleted while the traffic migration is
+      // in-progress, the target state will never be achieved so the operation
+      // will wait until its full 60 minute timeout.
+      lock(resource: 'update-traffic-lock', priority: 10) {
+         stage("Deleting") {
+            withVirtualenv.python3() {
+               deleteVersion();
+            }
          }
       }
    }

--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -107,9 +107,10 @@ onMaster('30m') {
       // 0%. If a revision is deleted while the traffic migration is
       // in-progress, the target state will never be achieved so the operation
       // will wait until its full 60 minute timeout.
-      lock(resource: 'update-traffic-lock', priority: 10) {
-         stage("Deleting") {
-            withVirtualenv.python3() {
+      
+      stage("Deleting") {
+         withVirtualenv.python3() {
+            lock(resource: 'update-traffic-lock', priority: 10) {
                deleteVersion();
             }
          }

--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -87,29 +87,31 @@ onMaster('30m') {
       stage("Initializing webapp") {
          _setupWebapp();
       }
-      // Acquire the shared mutex with deploy-webapp's set default step. If
-      // set default takes a long time, we may get multiple delete-version jobs
-      // queued for the same version(s). This should no-op just fine.
-      //
-      // While we would like to prioritize deploy-webapp over delete-versions by
-      // skipping this job when locked, we also don't want to lose any delete
-      // requests that wouldn't be automatically retried, such as ZND deletion
-      // requests from users. Since GCP support has advised us to keep our
-      // traffic tag count as low as possible, we really don't want to miss any
-      // ZND deletions. Setting lock priority lower than in the set default step
-      // should be a good middle ground.
-      //
-      // https://plugins.jenkins.io/lockable-resources/#plugin-content-lock-queue-priority
-      //
-      // We do this because the update-traffic command creates a
-      // LongRunningOperation that expects a specific target traffic allocation
-      // across all revisions with traffic tags and/or a traffic % higher than
-      // 0%. If a revision is deleted while the traffic migration is
-      // in-progress, the target state will never be achieved so the operation
-      // will wait until its full 60 minute timeout.
-      
       stage("Deleting") {
          withVirtualenv.python3() {
+            // Acquire the shared mutex with deploy-webapp's set default step.
+            // If set default takes a long time, we may get multiple
+            // delete-version jobs queued for the same version(s). This should
+            // no-op just fine.
+            //
+            // While we would like to prioritize deploy-webapp over
+            // delete-versions by skipping this job when locked, we also don't
+            // want to lose any delete requests that wouldn't be automatically
+            // retried, such as ZND deletion requests from users. Since GCP
+            // support has advised us to keep our traffic tag count as low as
+            // possible, we really don't want to miss any ZND deletions. Setting
+            // lock priority lower than in the set default step should be a good
+            // middle ground.
+            //
+            // https://plugins.jenkins.io/lockable-resources/#plugin-content-lock-queue-priority
+            //
+            // We do this because the update-traffic command creates a
+            // LongRunningOperation that expects a specific target traffic
+            // allocation across all revisions with traffic tags and/or a
+            // traffic % higher than 0%. If a revision is deleted while the
+            // traffic migration is in-progress, the target state will never be
+            // achieved so the operation will wait until its full 60 minute
+            // timeout.
             lock(resource: 'update-traffic-lock', priority: 10) {
                deleteVersion();
             }

--- a/jobs/deploy-webapp.groovy
+++ b/jobs/deploy-webapp.groovy
@@ -954,7 +954,21 @@ onMaster('4h') {
          try {
             stage("Promoting and monitoring") {
                withVirtualenv.python3() {
-                  setDefaultAndMonitor();
+                  // Wait for a concurrent delete-version delete stage to finish
+                  // before performing any traffic migrations. Use high priority
+                  // to jump in front of any lock-queued but not-yet-in-progress
+                  // delete stages.
+                  //
+                  // We do this because the update-traffic command creates a
+                  // LongRunningOperation that expects a specific target traffic
+                  // allocation across all revisions with traffic tags and/or a
+                  // traffic % higher than 0%. If a revision is deleted while
+                  // the traffic migration is in-progress, the target state will
+                  // never be achieved so the operation will wait until its full
+                  // 60 minute timeout.
+                  lock(resource: 'update-traffic-lock', priority: 20) {
+                     setDefaultAndMonitor();
+                  }
                }
             }
             // Unlike above, we do not need to verify second smoke tests


### PR DESCRIPTION
## Summary:
We have been running into a particularly frusting issue a few times a
day for the last month: the update-traffic command will hang until its
60 minute timeout despite the traffic migration being complete 5-10
minutes in. We've received a preliminary RCA from Google's engineering
teams:

1. When the update-traffic command is kicked off for a given service, it
   creates an intent that expects the traffic allocation across all
   revisions (with traffic tags or higher than 0% traffic allocation) to
   achieve a specific target state.
2. A DeleteRevision is kicked off for the same service that deletes one
   of the revisions specified in the target traffic allocation state.
3. As a result, the service-level intent for the update-traffic command
   can never be fulfilled. The command then polls until timeout.
   
https://khanacademy.slack.com/archives/C027VGTEVAA/p1773670531790489?thread_ts=1772132199.620719&cid=C027VGTEVAA

Prevent this from happening by having both set-default and
delete-versions share a lockable resource, `update-traffic-lock`. Set
priority higher for set-default as we want to minimize the slowdown the
lock may introduce to our deploys.

The lockable resource has been created in jenkins at:

https://jenkins.khanacademy.org/manage/configure

<img width="1589" height="497" alt="Screenshot 2026-03-16 at 5 05 14 PM" src="https://github.com/user-attachments/assets/8e8deafa-3bc6-4abf-a82a-1bb69c1077f8" />

Issue: https://khanacademy.atlassian.net/browse/INFRA-10970

Test plan:

1. Monitor the deployment queue.
2. Every day the issue does not happen, report it to this slack thread:
   https://khanacademy.slack.com/archives/C027VGTEVAA/p1772132199620719
3. If the issue does happen again, report to the same thread for
   advisement.
4. Once no occurances of the issue have been reported for a week, close
   the thread with Google.