### PR TITLE
Properly handle branches with slashes.

### DIFF
--- a/safe_git.sh
+++ b/safe_git.sh
@@ -318,7 +318,7 @@ pull() {
 push() {
     (
     cd "$1"
-    branch=`git rev-parse --symbolic-full-name HEAD | sed 's,^.*/,,'`
+    branch=`git rev-parse --symbolic-full-name HEAD | sed -e 's,^refs/heads/,,' -e 's,^refs/remotes/,,' -e 's,^refs/tags/,,'`
     # In case there have been any changes since the script began, we
     # do 'pull; push'.  On failure, we undo all our work.
     _fetch
@@ -346,7 +346,7 @@ update_submodule_pointer_to_master() {
     shift
     dir="$1"
     shift
-    branch=`git rev-parse --symbolic-full-name HEAD | sed 's,^.*/,,'`
+    branch=`git rev-parse --symbolic-full-name HEAD | sed -e 's,^refs/heads/,,' -e 's,^refs/remotes/,,' -e 's,^refs/tags/,,'`
     pull_in_branch . "$branch"
     ( cd "$dir" && timeout 10m git checkout master )
     timeout 10m git add "$dir"


### PR DESCRIPTION
## Summary:
I can't believe this hasn't gotten us until trouble before!  I guess
because a) we don't use submodules anymore, and b) most of our jobs
don't try to push to a branch except for `master`, which doesn't have
a slash in it.  But some jobs do, and we ran into trouble there.

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1775057192305139

## Test plan:
I ran:
```
git rev-parse --symbolic-full-name HEAD | sed -e 's,^refs/heads/,,' -e 's,^refs/remotes/,,' -e 's,^refs/tags/,,'
```
locally and it emitted `csilvers`, same as before this change.