### PR TITLE
When runing gc_all_repos, do a "safe" fetch.

### DIFF
--- a/weekly-maintenance-jobs.sh
+++ b/weekly-maintenance-jobs.sh
@@ -111,7 +111,9 @@ gc_all_repos() {
         echo "Fetching in $dir"
         cd "$dir"
 
-        git fetch --progress origin
+        # I'm not sure if it's actually useful to have tags in these
+        # "canonical" repos, but I figure it can't hurt.
+        git fetch --tags --prune --prune-tags --force --progress origin
         git gc
         )
     done


### PR DESCRIPTION
## Summary:
I saw getting this error in the gc_all_repos weekly jenkins job:
> 18:16:50  error: cannot lock ref 'refs/remotes/origin/rjcorwin/cgvc-frontend-attribution': 'refs/remotes/origin/rjcorwin' exists; cannot create 'refs/remotes/origin/rjcorwin/cgvc-frontend-attribution'

I realized that I can avoid such errors by using the same "safe" fetch
command that we use in safe_git.sh.  This PR changes things to do that.

Issue: https://jenkins.khanacademy.org/job/misc/job/webapp-maintenance/414/execution/node/330/log/

## Test plan:
I successfully ran this command manually on jenkins-server as the
jenkins user, in /mnt/jenkins/repositories/frontend.  We'll see next
week if it fully resolves the problem!

Subscribers: @rjcorwin