### PR TITLE
Use the new syntax for should_deploy.py and trivial_diffs.py.

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -322,7 +322,8 @@ def initializeGlobals() {
          // against the currently live version, and the consequences of doing
          // something else are greater, so we prohibit the dangerous thing.
          if (params.BASE_REVISION) {
-            shouldDeployArgs += ["--from-commit", params.BASE_REVISION]
+            shouldDeployArgs += [
+               "--commit-range", "${params.BASE_REVISION}...HEAD"]
          }
 
          if (params.SERVICES == "auto") {

--- a/jobs/determine-webapp-services.groovy
+++ b/jobs/determine-webapp-services.groovy
@@ -106,8 +106,8 @@ def determineServicesToDeploy() {
                def shouldDeployArgs = ['deploy/should_deploy.py'];
                // Diff against BASE_REVISION if set.
                if (params.BASE_REVISION) {
-                     shouldDeployArgs += [
-                        '--from-commit', params.BASE_REVISION]
+                  shouldDeployArgs += [
+                     '--commit-range', "${params.BASE_REVISION}...HEAD"]
                }
                services = exec.outputOf(shouldDeployArgs).split('\n');
             } catch(e) {

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -238,7 +238,7 @@ def runTestServer() {
             // changed between BASE_REVISION and GIT_REVISION.  We ignore
             // files where only sync tags have changed; those can't affect
             // tests.
-            sh("deploy/trivial_diffs.py ${exec.shellEscape(params.BASE_REVISION)} ${exec.shellEscape(GIT_SHA1)} > ../trivial_diffs.txt");
+            sh("deploy/trivial_diffs.py ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} > ../trivial_diffs.txt");
             sh("git diff --name-only --diff-filter=ACMRTUB ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} | fgrep -vx -f ../trivial_diffs.txt | testing/all_tests_for.py - > ../files_to_test.txt");
             // Sometimes we need to run some extra tests for deletd files.
             sh("git diff --name-only --diff-filter=D ${exec.shellEscape(params.BASE_REVISION)}...${exec.shellEscape(GIT_SHA1)} | fgrep -vx -f ../trivial_diffs.txt | testing/all_tests_for.py --deleted-mode - >> ../files_to_test.txt");


### PR DESCRIPTION
## Summary:
These scripts used to take a from-commit and to-commit, and would
internally combine them to "<from_commit>...<to_commit>".  I changed
the script to accept the actual commit-range explicitly instead.  Now
I'm changing jenkins to use that new format.

I didn't change jenkins earlier because I didn't want to break znd's
that didn't have the updates to should_deploy.py and trivial_diffs.py.
But those files were updated a month ago, and I don't expect any znd's
to be based on such old code, so I think it's safe to do this now!

Issue: none

## Test plan:
Fingers crossed