### PR TITLE
Add a test for the merge-branches job

### DIFF
--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -81,6 +81,10 @@ def checkArgs() {
 
 
 String getGaeVersionName() {
+   if (env.GAE_VERSION_NAME) {
+     echo("Using GAE_VERSION_NAME from env: ${env.GAE_VERSION_NAME}");
+     return env.GAE_VERSION_NAME;
+   }
    dir('webapp') {
      String gaeVersionName = exec.outputOf(["make", "gae_version_name"]);
      echo("Found gae version name: ${gaeVersionName}");

--- a/scripts/merge_branches_runner
+++ b/scripts/merge_branches_runner
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v groovy >/dev/null 2>&1; then
+  echo "groovy is required to run merge_branches_runner (Jenkins harness mode)." >&2
+  exit 2
+fi
+
+MERGE_BRANCHES_REPO_ROOT="$REPO_ROOT" \
+  exec groovy "$SCRIPT_DIR/merge_branches_runner_jenkins_harness.groovy" "$@"

--- a/scripts/merge_branches_runner_jenkins_harness.groovy
+++ b/scripts/merge_branches_runner_jenkins_harness.groovy
@@ -15,7 +15,7 @@ Map<String, String> parseArgs(String[] args) {
 Map runProcess(List<String> cmd, File cwd, boolean captureOutput = true) {
     ProcessBuilder pb = new ProcessBuilder(cmd)
     pb.directory(cwd)
-    pb.redirectErrorStream(true)
+    pb.redirectErrorStream(true) // stderr merged into stdout so exceptions carry full output
     Process p = pb.start()
     String out = captureOutput ? p.inputStream.getText("UTF-8").trim() : ""
     int rc = p.waitFor()
@@ -63,6 +63,7 @@ Closure dirStep = { String path, Closure body ->
 Closure echoStep = { String msg -> println(msg) }
 Closure errorStep = { String msg -> throw new RuntimeException(msg) }
 
+// Populated after shell.parse() so the classes defined in harnessPrelude are available.
 Class failedBuildClass = null
 Class execResultClass = null
 

--- a/scripts/merge_branches_runner_jenkins_harness.groovy
+++ b/scripts/merge_branches_runner_jenkins_harness.groovy
@@ -1,0 +1,191 @@
+#!/usr/bin/env groovy
+import groovy.json.JsonOutput
+
+Map<String, String> parseArgs(String[] args) {
+    Map<String, String> out = [:]
+    for (int i = 0; i < args.length; i++) {
+        if (args[i].startsWith("--") && i + 1 < args.length) {
+            out[args[i].substring(2)] = args[i + 1]
+            i++
+        }
+    }
+    return out
+}
+
+Map runProcess(List<String> cmd, File cwd, boolean captureOutput = true) {
+    ProcessBuilder pb = new ProcessBuilder(cmd)
+    pb.directory(cwd)
+    pb.redirectErrorStream(true)
+    Process p = pb.start()
+    String out = captureOutput ? p.inputStream.getText("UTF-8").trim() : ""
+    int rc = p.waitFor()
+    return [command: cmd.join(" "), exitCode: rc, output: out]
+}
+
+void appendApiLog(String method, String commitId, String status, String sha1, String gaeVersionName) {
+    String path = System.getenv("MERGE_BRANCHES_API_LOG")
+    if (!path) {
+        return
+    }
+    def payload = [
+        method: method,
+        commit_id: commitId,
+        status: status,
+        sha1: sha1,
+        gae_version_name: gaeVersionName,
+    ]
+    new File(path) << JsonOutput.toJson(payload) + "\n"
+}
+
+Map<String, String> opts = parseArgs(args)
+String revisionsInput = opts["git-revisions"]
+String commitId = opts["commit-id"]
+String description = opts["revision-description"] ?: ""
+if (!revisionsInput || !commitId) {
+    System.err.println("Usage: --git-revisions <...> --commit-id <...> [--revision-description <...>]")
+    System.exit(2)
+}
+
+File workspace = new File(System.getenv("MERGE_BRANCHES_WORKDIR") ?: ".").canonicalFile
+workspace.mkdirs()
+File[] currentDir = [workspace]
+
+Closure dirStep = { String path, Closure body ->
+    File prev = currentDir[0]
+    currentDir[0] = new File(prev, path).canonicalFile
+    try {
+        body.call()
+    } finally {
+        currentDir[0] = prev
+    }
+}
+
+Closure echoStep = { String msg -> println(msg) }
+Closure errorStep = { String msg -> throw new RuntimeException(msg) }
+
+Class failedBuildClass = null
+Class execResultClass = null
+
+Object notifyStep = new Object() {
+    void fail(String msg) {
+        throw failedBuildClass.getConstructor(String.class).newInstance(msg)
+    }
+
+    void fail(String msg, Throwable t) {
+        throw failedBuildClass.getConstructor(String.class)
+            .newInstance(msg + ": " + t.getMessage())
+    }
+
+    void rethrowIfAborted(Throwable t) {
+        // No-op in harness.
+    }
+}
+
+Object withSecretsStep = new Object() {
+    void slackAlertlibOnly(Closure c) { c.call() }
+}
+
+Object execStep = new Object() {
+    private Object asExecResult(Map r) {
+        def result = execResultClass.newInstance()
+        result.command = r.command
+        result.exitCode = r.exitCode
+        result.output = r.output
+        return result
+    }
+
+    private Object runGit(List<String> args) {
+        return runProcess(args, currentDir[0])
+    }
+
+    private Object runSafeGit(List<String> args) {
+        String subcommand = args[1]
+        if (subcommand == "clone") {
+            return runProcess(["git", "clone", "-q", args[2], args[3]], currentDir[0])
+        }
+        if (subcommand == "simple_fetch") {
+            return runProcess(["git", "-C", args[2], "fetch", "--all", "--tags"], currentDir[0])
+        }
+        if (subcommand == "clean_branches") {
+            // Safe no-op for test harness; we always use fresh clones.
+            return [command: args.join(" "), exitCode: 0, output: ""]
+        }
+        throw new RuntimeException("Unsupported safe_git subcommand in harness: ${subcommand}")
+    }
+
+    private Object runAny(List<String> arglist) {
+        if (!arglist.isEmpty() && arglist[0] == "jenkins-jobs/safe_git.sh") {
+            return runSafeGit(arglist)
+        }
+        return runGit(arglist)
+    }
+
+    void call(List<String> arglist) {
+        def r = runAny(arglist)
+        if (r.exitCode != 0) {
+            throw new RuntimeException(r.output)
+        }
+    }
+
+    String outputOf(List<String> arglist) {
+        def r = runAny(arglist)
+        if (r.exitCode != 0) {
+            throw new RuntimeException(r.output)
+        }
+        return r.output
+    }
+
+    Integer statusOf(List<String> arglist) {
+        def r = runAny(arglist)
+        return r.exitCode
+    }
+
+    Object runCommand(List<String> arglist) {
+        return asExecResult(runAny(arglist))
+    }
+}
+
+Binding binding = new Binding()
+binding.setProperty("env", [
+    KA_WEBAPP_REPO_URL: (System.getenv("KA_WEBAPP_REPO_URL") ?: "git@github.com:Khan/webapp"),
+    BUILD_TAG: (System.getenv("BUILD_TAG") ?: "merge-branches-harness"),
+])
+binding.setProperty("dir", dirStep)
+binding.setProperty("echo", echoStep)
+binding.setProperty("error", errorStep)
+binding.setProperty("notify", notifyStep)
+binding.setProperty("withSecrets", withSecretsStep)
+binding.setProperty("exec", execStep)
+binding.setProperty("fileExists", { String p -> new File(currentDir[0], p).exists() })
+binding.setProperty("readFile", { String p -> new File(currentDir[0], p).text })
+binding.setProperty("writeFile", { Map m -> new File(currentDir[0], m.file as String).text = m.text as String })
+
+String repoRoot = System.getenv("MERGE_BRANCHES_REPO_ROOT") ?: "."
+String kaGitSource = new File(repoRoot, "vars/kaGit.groovy").text
+String harnessPrelude = """
+class FailedBuild extends RuntimeException {
+    FailedBuild(String message) { super(message) }
+}
+
+class ExecResult {
+    String command
+    Integer exitCode
+    String output
+}
+"""
+GroovyShell shell = new GroovyShell(binding)
+Script kaGit = shell.parse(harnessPrelude + "\n" + kaGitSource)
+failedBuildClass = kaGit.class.classLoader.loadClass("FailedBuild")
+execResultClass = kaGit.class.classLoader.loadClass("ExecResult")
+
+try {
+    String tagName = "buildmaster-${commitId}-${new Date().format('yyyyMMdd-HHmmss')}"
+    String sha1 = kaGit.invokeMethod("mergeRevisions", [revisionsInput, tagName, description] as Object[])
+    String gaeVersionName = System.getenv("GAE_VERSION_NAME") ?: ""
+    appendApiLog("notifyMergeResult", commitId, "success", sha1, gaeVersionName)
+    println(sha1)
+} catch (Throwable t) {
+    appendApiLog("notifyMergeResult", commitId, "failed", null, null)
+    System.err.println(t.getMessage())
+    System.exit(1)
+}

--- a/tests/merge_branches_integration_test.sh
+++ b/tests/merge_branches_integration_test.sh
@@ -25,16 +25,16 @@ assert_contains() {
 
 create_remote_fixture() {
   local dir="$1"
-  git init --bare --initial-branch=master "$dir/origin.git" >/dev/null
-  git clone -q "$dir/origin.git" "$dir/seed" >/dev/null
+  git init --quiet --bare --initial-branch=master "$dir/origin.git" >/dev/null 2>&1
+  git clone -q "$dir/origin.git" "$dir/seed" >/dev/null 2>&1
   (
     cd "$dir/seed"
     git config user.name tester
     git config user.email tester@example.com
     echo "base" > app.txt
     git add app.txt
-    git commit -m "base" >/dev/null
-    git push origin HEAD:master >/dev/null
+    git commit -q -m "base" >/dev/null 2>&1
+    git push --quiet origin HEAD:master >/dev/null 2>&1
   )
 }
 
@@ -66,17 +66,17 @@ test_happy_path_merge() {
 
   (
     cd "$dir/seed"
-    git checkout -b feature >/dev/null
+    git checkout -q -b feature >/dev/null 2>&1
     echo "feature" > feature.txt
     git add feature.txt
-    git commit -m "feature change" >/dev/null
-    git push origin feature >/dev/null
+    git commit -q -m "feature change" >/dev/null 2>&1
+    git push --quiet origin feature >/dev/null 2>&1
 
-    git checkout master >/dev/null
+    git checkout -q master >/dev/null 2>&1
     echo "master" > master.txt
     git add master.txt
-    git commit -m "master change" >/dev/null
-    git push origin master >/dev/null
+    git commit -q -m "master change" >/dev/null 2>&1
+    git push --quiet origin master >/dev/null 2>&1
   )
 
   : > "$dir/api.ndjson"
@@ -86,7 +86,7 @@ test_happy_path_merge() {
   sha="$(tail -n 1 "$dir/out.txt" | tr -d '\n')"
   [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "runner did not output a sha"
 
-  git clone -q "$dir/origin.git" "$dir/verify" >/dev/null
+  git clone -q "$dir/origin.git" "$dir/verify" >/dev/null 2>&1
   local parent_count
   parent_count="$(cd "$dir/verify" && git rev-list --parents -n 1 "$sha" | awk '{print NF-1}')"
   assert_eq "$parent_count" "2" "happy path should produce a merge commit"
@@ -129,17 +129,17 @@ test_merge_conflict_failure() {
 
   (
     cd "$dir/seed"
-    git checkout -b feature >/dev/null
+    git checkout -q -b feature >/dev/null 2>&1
     echo "feature-value" > conflict.txt
     git add conflict.txt
-    git commit -m "feature adds conflict file" >/dev/null
-    git push origin feature >/dev/null
+    git commit -q -m "feature adds conflict file" >/dev/null 2>&1
+    git push --quiet origin feature >/dev/null 2>&1
 
-    git checkout master >/dev/null
+    git checkout -q master >/dev/null 2>&1
     echo "master-value" > conflict.txt
     git add conflict.txt
-    git commit -m "master adds conflict file" >/dev/null
-    git push origin master >/dev/null
+    git commit -q -m "master adds conflict file" >/dev/null 2>&1
+    git push --quiet origin master >/dev/null 2>&1
   )
 
   : > "$dir/api.ndjson"

--- a/tests/merge_branches_integration_test.sh
+++ b/tests/merge_branches_integration_test.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNNER="$ROOT/scripts/merge_branches_runner"
 
+TEMP_DIRS=()
+cleanup() { [[ ${#TEMP_DIRS[@]} -gt 0 ]] && rm -rf "${TEMP_DIRS[@]}"; }
+trap cleanup EXIT
+
 fail() {
   echo "FAIL: $*" >&2
   exit 1
@@ -49,6 +53,7 @@ run_runner() {
   (
     cd "$dir"
     KA_WEBAPP_REPO_URL="$dir/origin.git" \
+    MERGE_BRANCHES_WORKDIR="$dir" \
     GAE_VERSION_NAME="test-gae-version" \
     MERGE_BRANCHES_API_LOG="$log_file" \
     "$RUNNER" \
@@ -62,6 +67,7 @@ run_runner() {
 test_happy_path_merge() {
   local dir
   dir="$(mktemp -d /tmp/merge-branches-happy.XXXXXX)"
+  TEMP_DIRS+=("$dir")
   create_remote_fixture "$dir"
 
   (
@@ -105,6 +111,7 @@ test_happy_path_merge() {
 test_invalid_committish_failure() {
   local dir
   dir="$(mktemp -d /tmp/merge-branches-invalid.XXXXXX)"
+  TEMP_DIRS+=("$dir")
   create_remote_fixture "$dir"
 
   : > "$dir/api.ndjson"
@@ -125,6 +132,7 @@ test_invalid_committish_failure() {
 test_merge_conflict_failure() {
   local dir
   dir="$(mktemp -d /tmp/merge-branches-conflict.XXXXXX)"
+  TEMP_DIRS+=("$dir")
   create_remote_fixture "$dir"
 
   (

--- a/tests/merge_branches_integration_test.sh
+++ b/tests/merge_branches_integration_test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="$ROOT/scripts/merge_branches_runner"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local got="$1"
+  local want="$2"
+  local msg="$3"
+  [[ "$got" == "$want" ]] || fail "$msg (got='$got', want='$want')"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  [[ "$haystack" == *"$needle"* ]] || fail "$msg (missing '$needle')"
+}
+
+create_remote_fixture() {
+  local dir="$1"
+  git init --bare --initial-branch=master "$dir/origin.git" >/dev/null
+  git clone -q "$dir/origin.git" "$dir/seed" >/dev/null
+  (
+    cd "$dir/seed"
+    git config user.name tester
+    git config user.email tester@example.com
+    echo "base" > app.txt
+    git add app.txt
+    git commit -m "base" >/dev/null
+    git push origin HEAD:master >/dev/null
+  )
+}
+
+run_runner() {
+  local dir="$1"
+  local revisions="$2"
+  local commit_id="$3"
+  local description="$4"
+  local out_file="$5"
+  local log_file="$6"
+
+  (
+    cd "$dir"
+    KA_WEBAPP_REPO_URL="$dir/origin.git" \
+    GAE_VERSION_NAME="test-gae-version" \
+    MERGE_BRANCHES_API_LOG="$log_file" \
+    "$RUNNER" \
+      --git-revisions "$revisions" \
+      --commit-id "$commit_id" \
+      --revision-description "$description" \
+      >"$out_file" 2>"$out_file.err"
+  )
+}
+
+test_happy_path_merge() {
+  local dir
+  dir="$(mktemp -d /tmp/merge-branches-happy.XXXXXX)"
+  create_remote_fixture "$dir"
+
+  (
+    cd "$dir/seed"
+    git checkout -b feature >/dev/null
+    echo "feature" > feature.txt
+    git add feature.txt
+    git commit -m "feature change" >/dev/null
+    git push origin feature >/dev/null
+
+    git checkout master >/dev/null
+    echo "master" > master.txt
+    git add master.txt
+    git commit -m "master change" >/dev/null
+    git push origin master >/dev/null
+  )
+
+  : > "$dir/api.ndjson"
+  run_runner "$dir" "master + feature" "c1" "happy path" "$dir/out.txt" "$dir/api.ndjson"
+
+  local sha
+  sha="$(tail -n 1 "$dir/out.txt" | tr -d '\n')"
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "runner did not output a sha"
+
+  git clone -q "$dir/origin.git" "$dir/verify" >/dev/null
+  local parent_count
+  parent_count="$(cd "$dir/verify" && git rev-list --parents -n 1 "$sha" | awk '{print NF-1}')"
+  assert_eq "$parent_count" "2" "happy path should produce a merge commit"
+
+  local tag_count
+  tag_count="$(cd "$dir/verify" && git tag --points-at "$sha" | grep -c '^buildmaster-c1-' || true)"
+  assert_eq "$tag_count" "1" "merge result should be tagged"
+
+  local log
+  log="$(cat "$dir/api.ndjson")"
+  assert_contains "$log" '"method":"notifyMergeResult"' "missing notification call"
+  assert_contains "$log" '"status":"success"' "missing success status"
+  assert_contains "$log" '"gae_version_name":"test-gae-version"' "missing gae version"
+}
+
+test_invalid_committish_failure() {
+  local dir
+  dir="$(mktemp -d /tmp/merge-branches-invalid.XXXXXX)"
+  create_remote_fixture "$dir"
+
+  : > "$dir/api.ndjson"
+  if run_runner "$dir" "master + does-not-exist" "c2" "invalid" "$dir/out.txt" "$dir/api.ndjson"; then
+    fail "runner should fail for invalid committish"
+  fi
+
+  local err
+  err="$(cat "$dir/out.txt.err")$(cat "$dir/out.txt")"
+  assert_contains "$err" "Cannot find 'does-not-exist'" "invalid committish error should be clear"
+
+  local log
+  log="$(cat "$dir/api.ndjson")"
+  assert_contains "$log" '"status":"failed"' "invalid committish should emit failed notification"
+  assert_contains "$log" '"sha1":null' "failed notification should have null sha"
+}
+
+test_merge_conflict_failure() {
+  local dir
+  dir="$(mktemp -d /tmp/merge-branches-conflict.XXXXXX)"
+  create_remote_fixture "$dir"
+
+  (
+    cd "$dir/seed"
+    git checkout -b feature >/dev/null
+    echo "feature-value" > conflict.txt
+    git add conflict.txt
+    git commit -m "feature adds conflict file" >/dev/null
+    git push origin feature >/dev/null
+
+    git checkout master >/dev/null
+    echo "master-value" > conflict.txt
+    git add conflict.txt
+    git commit -m "master adds conflict file" >/dev/null
+    git push origin master >/dev/null
+  )
+
+  : > "$dir/api.ndjson"
+  if run_runner "$dir" "master + feature" "c3" "conflict" "$dir/out.txt" "$dir/api.ndjson"; then
+    fail "runner should fail on merge conflict"
+  fi
+
+  local err
+  err="$(cat "$dir/out.txt.err")$(cat "$dir/out.txt")"
+  assert_contains "$err" "CONFLICT" "merge conflict should surface git conflict output"
+
+  local log
+  log="$(cat "$dir/api.ndjson")"
+  assert_contains "$log" '"status":"failed"' "merge conflict should emit failed notification"
+}
+
+main() {
+  test_happy_path_merge
+  test_invalid_committish_failure
+  test_merge_conflict_failure
+  echo "PASS: merge_branches integration tests"
+}
+
+main "$@"

--- a/vars/kaGit.groovy
+++ b/vars/kaGit.groovy
@@ -269,6 +269,7 @@ def safeMergeFromMaster(dir, commitToMergeInto, submodules=[]) {
 // Notes:
 // - Used by merge-granches.groovy and deploy-znd.groovy.
 String mergeRevisions(gitRevisions, tagName, description) {
+   String repoUrl = env.KA_WEBAPP_REPO_URL ?: "git@github.com:Khan/webapp";
    List<String> allRevisions = gitRevisions.split(/\+/);
 
    // Trim passed revisions for consistent ouput formatting.
@@ -276,7 +277,7 @@ String mergeRevisions(gitRevisions, tagName, description) {
       allRevisions[i] = allRevisions[i].trim();
    }
 
-   quickClone("git@github.com:Khan/webapp", "webapp", allRevisions[0]);
+   quickClone(repoUrl, "webapp", allRevisions[0]);
    dir('webapp') {
       // We need to reset before fetching, because if a previous incomplete
       // merge left .gitmodules in a weird state, git will fail to read its
@@ -293,7 +294,7 @@ String mergeRevisions(gitRevisions, tagName, description) {
    // Do the merge(s)!
    dir('webapp') {
       for (Integer i = 0; i < allRevisions.size(); i++) {
-         String branchSha1 = resolveCommittish("git@github.com:Khan/webapp",
+         String branchSha1 = resolveCommittish(repoUrl,
                                                allRevisions[i]);
          if (i == 0) {
             // First, checkout the base revision. Even if there aren't


### PR DESCRIPTION
## Summary:
This is to prepare for migrating the job to a webapp github action. I wanted there to be a test that could run both on the groovy and on the new go job, to verify that theyb behave the same.

codex did most of it.

Issue: none

## Test plan:
`./tests/merge_branches_integration_test.sh`