### PR TITLE
Fix ref calculation for github_bridge w/ webapp-test job

### DIFF
--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -103,7 +103,7 @@ onMaster('1h') {
                                          params.REVISION_DESCRIPTION);
          String gaeVersionName = getGaeVersionName();
          buildmaster.notifyMergeResult(params.COMMIT_ID, 'success',
-                                       sha1, gaeVersionName);
+                                       sha1, gaeVersionName, tagName);
       } catch (e) {
          // We don't really care about the difference between aborted and failed;
          // we can't use notify because we want somewhat special semantics; and

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -109,7 +109,7 @@ onMaster('1h') {
          // we can't use notify because we want somewhat special semantics; and
          // without all the things notify does it's hard to tell the difference
          // between aborted and failed.  So we don't bother.
-         buildmaster.notifyMergeResult(params.COMMIT_ID, 'failed', null, null);
+         buildmaster.notifyMergeResult(params.COMMIT_ID, 'failed', null, null, null);
          throw e;
       }
    }

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -552,11 +552,12 @@ onWorker('ka-test-ec2', '5h') {     // timeout
                          what: 'webapp-test']]) {
       initializeGlobals();
 
-      if (params.USE_GITHUB_BRIDGE && !_isSha(params.GIT_REVISION)) {
+      if (params.USE_GITHUB_BRIDGE && (!_isSha(params.GIT_REVISION) || params.REVISION_DESCRIPTION)) {
+         def ref = _isSha(params.GIT_REVISION) ? params.REVISION_DESCRIPTION : params.GIT_REVISION
          runGithubAction(
             repo: "Khan/webapp",
             workflow: "webapp-test.yml",
-            ref: params.GIT_REVISION,
+            ref: ref,
             headSha: GIT_SHA1,
             inputs: [
                git_revision:          params.GIT_REVISION,

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -558,12 +558,11 @@ onWorker('ka-test-ec2', '5h') {     // timeout
                          what: 'webapp-test']]) {
       initializeGlobals();
 
-      if (params.USE_GITHUB_BRIDGE && (!_isSha(params.GIT_REVISION) || params.REVISION_DESCRIPTION)) {
-         def ref = _isSha(params.GIT_REVISION) ? params.REVISION_DESCRIPTION : params.GIT_REVISION
+      if (params.USE_GITHUB_BRIDGE && params.GIT_TAG) {
          runGithubAction(
             repo: "Khan/webapp",
             workflow: "webapp-test.yml",
-            ref: ref,
+            ref: params.GIT_TAG,
             headSha: GIT_SHA1,
             inputs: [
                git_revision:          params.GIT_REVISION,

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -112,6 +112,12 @@ that are part of the same deploy.  Write-only; not used by this script.""",
    ""
 
 ).addStringParam(
+   "GIT_TAG",
+   """Set by the buildmaster to the git tag associated with GIT_REVISION.
+Defaults to empty if no tag is known.""",
+   ""
+
+).addStringParam(
    "JOB_PRIORITY",
    """The priority of the job to be run (a lower priority means it is run
 sooner). The Priority Sorter plugin reads this parameter in to reorder jobs

--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -123,14 +123,15 @@ def notifyStatus(job, result, sha1) {
    return _makeHttpRequestAndAlert("commits", "PATCH", params);
 }
 
-def notifyMergeResult(commitId, result, sha1, gae_version_name) {
+def notifyMergeResult(commitId, result, sha1, gae_version_name, git_tag=null) {
    String shaToLog = sha1 ? sha1 : "No merged SHA"
    echo("Marking buildmaster commit #${commitId} as ${result}: ${shaToLog}");
    def params = [
       commit_id: commitId,
       result: result,
       git_sha: sha1,
-      gae_version_name: gae_version_name
+      gae_version_name: gae_version_name,
+      git_tag: git_tag
    ];
    return _makeHttpRequestAndAlert("commits/merge", "PATCH", params);
 }

--- a/vars/buildmaster.groovy
+++ b/vars/buildmaster.groovy
@@ -123,7 +123,7 @@ def notifyStatus(job, result, sha1) {
    return _makeHttpRequestAndAlert("commits", "PATCH", params);
 }
 
-def notifyMergeResult(commitId, result, sha1, gae_version_name, git_tag=null) {
+def notifyMergeResult(commitId, result, sha1, gae_version_name, git_tag) {
    String shaToLog = sha1 ? sha1 : "No merged SHA"
    echo("Marking buildmaster commit #${commitId} as ${result}: ${shaToLog}");
    def params = [


### PR DESCRIPTION
## Summary:
I was trying to test out the new github bridge, passing in all the same parameters buildmaster does but w/ the USE_GITHUB_BRIDGE flag on, and it didn't work, because buildmaster passes a SHA for GIT_REVISION. Which I should have anticipated. Fortunately, buildmaster passes a branch ref as REVISION_DESCRIPTION, so I can use that.

Issue: none

## Test plan:
🤞