### PR TITLE
[🔥AUDIT🔥] Fix onMaster invocation

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -601,7 +601,7 @@ def run(Boolean useGithub) {
 def useGithub = params.USE_GITHUB_BRIDGE && params.GIT_TAG;
 if (useGithub) {
    // No need to spin up a worker just to wait on github responding
-   onMaster {
+   onMaster('30m') {
       run(true)
    }
 } else {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
crazy that in 2026 we have to interact with a language that doesn't have static validation of method invocations 😭

turns out you can't just `onMaster {` you need to give it a timeout.

Issue: https://jenkins.khanacademy.org/job/deploy/job/webapp-test/340742/console

## Test plan:
🤞😭