### PR TITLE
[🔥AUDIT🔥] Specify `-R repo` in the gh call when watching the test execution

### DIFF
--- a/vars/runGithubAction.groovy
+++ b/vars/runGithubAction.groovy
@@ -51,9 +51,9 @@ def _dispatch(Map args) {
 
 // Wait for a GitHub Actions workflow run to complete.
 // Blocks until the run finishes; fails the build if the run fails.
-def _wait(String runId, String githubToken) {
+def _wait(String repo, String runId, String githubToken) {
     withEnv(["GITHUB_TOKEN=${githubToken}"]) {
-        exec(["gh", "run", "watch", runId, "--exit-status"])
+        exec(["gh", "run", "watch", runId, "-R", repo, "--exit-status"])
     }
 }
 
@@ -68,5 +68,5 @@ def _wait(String runId, String githubToken) {
 def call(Map args) {
     def token = withSecrets.getGithubActionsToken();
     def runId = _dispatch(args + [token: token])
-    _wait(runId, token)
+    _wait(args.repo, runId, token)
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
When I tried running it, I saw this error
```
12:34:21  + gh run watch 25751129883 --exit-status
12:34:21  failed to determine base repo: failed to run git: fatal: not a git repository (or any of the parent directories): .git
```
because gh doesn't know what repo  we're in

Issue: https://jenkins.khanacademy.org/job/deploy/job/webapp-test/340796/console

## Test plan:
🤞