### PR TITLE
Better error message when a runGithubAction invocation fails

### DIFF
--- a/vars/runGithubAction.groovy
+++ b/vars/runGithubAction.groovy
@@ -15,6 +15,12 @@ import groovy.json.JsonSlurper
 // to locate the new run and return its ID.
 def _dispatch(Map args) {
     def payload = JsonOutput.toJson([ref: args.ref, inputs: args.inputs ?: [:]])
+    notify.log("GitHub Actions dispatch payload", [
+        level: "INFO",
+        repo: args.repo,
+        workflow: args.workflow,
+        payload: payload,
+    ])
 
     exec(["curl", "-sf", "-X", "POST",
           "-H", "Authorization: token ${args.token}",

--- a/vars/runGithubAction.groovy
+++ b/vars/runGithubAction.groovy
@@ -59,7 +59,14 @@ def _dispatch(Map args) {
 // Blocks until the run finishes; fails the build if the run fails.
 def _wait(String repo, String runId, String githubToken) {
     withEnv(["GITHUB_TOKEN=${githubToken}"]) {
-        exec(["gh", "run", "watch", runId, "-R", repo, "--exit-status"])
+        try {
+            exec(["gh", "run", "watch", runId, "-R", repo, "--exit-status"])
+        } catch (e) {
+            notify.rethrowIfAborted(e)
+            notify.fail("GitHub Actions workflow failed: " +
+                        "https://github.com/${repo}/actions/runs/${runId}\n\n" +
+                        e.getMessage(), e)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary:
That way we'll have a link to the actual run

I noticed that this message https://khanacademy.slack.com/archives/C0MKWDY8K/p1778700724252769 wasn't as helpful as I'd like.

Issue: none

## Test plan:
🤞