### PR TITLE
Send a tag for make-allcheck so it uses github actions for webapp_test

### DIFF
--- a/jobs/make-allcheck.groovy
+++ b/jobs/make-allcheck.groovy
@@ -34,6 +34,7 @@ def runAllTests() {
     build(job: '../deploy/webapp-test',
           parameters: [
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
+             string(name: 'GIT_TAG', value: "master"),
              string(name: 'BASE_REVISION', value: ""),
              string(name: 'SLACK_CHANNEL', value: "#backend"),
              booleanParam(name: 'FORCE', value: params.FORCE),

--- a/jobs/make-allcheck.groovy
+++ b/jobs/make-allcheck.groovy
@@ -11,6 +11,12 @@ import org.khanacademy.Setup;
 new Setup(steps
 
 ).addStringParam(
+   "GIT_TAG",
+   """The git tag or branch name to be used to select the github actions workflow.
+Defaults to master if no tag is provided.""",
+   "master"
+
+).addStringParam(
    "GIT_REVISION",
    """The git commit-hash to run tests at, or a symbolic name referring
 to such a commit-hash.""",
@@ -34,7 +40,7 @@ def runAllTests() {
     build(job: '../deploy/webapp-test',
           parameters: [
              string(name: 'GIT_REVISION', value: params.GIT_REVISION),
-             string(name: 'GIT_TAG', value: "master"),
+             string(name: 'GIT_TAG', value: params.GIT_TAG),
              string(name: 'BASE_REVISION', value: ""),
              string(name: 'SLACK_CHANNEL', value: "#backend"),
              booleanParam(name: 'FORCE', value: params.FORCE),

--- a/jobs/make-allcheck.groovy
+++ b/jobs/make-allcheck.groovy
@@ -13,7 +13,7 @@ new Setup(steps
 ).addStringParam(
    "GIT_TAG",
    """The git tag or branch name to be used to select the github actions workflow.
-Defaults to master if no tag is provided.""",
+If GIT_REVISION is a sha, leave this blank.""",
    "master"
 
 ).addStringParam(


### PR DESCRIPTION
## Summary:
required to let it use github actions.
defaults to master, same as GIT_REVISION.

Issue: none

## Test plan:
🤞