### PR TITLE
Fix build-current-sqlite to enable copying files to gcs again.

### DIFF
--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -7,6 +7,7 @@
 // Classes we use, under jenkins-jobs/src/.
 import org.khanacademy.Setup;
 // Vars we use, under jenkins-jobs/vars/.  This is just for documentation.
+//import vars.exec
 //import vars.kaGit
 //import vars.notify
 //import vars.onWorker
@@ -64,9 +65,12 @@ def runScript() {
          // and get the same effect.
          sh("docker exec webapp-datastore-emulator-1 dash -c 'kill 1'")
 
-         // Now upload the new database to gcs.
-         sh("gsutil cp ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz.bak");
-         sh("docker exec webapp-datastore-emulator-1 dash -c 'gsutil cp /var/datastore/dev_datastore.tar.gz ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz'");
+         // Now upload the new database to gcs.  We will need to copy over
+         // the gcloud service account token since the datastore container
+         // does not have access to it by default.
+         exec(["gsutil", "cp", "${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz", "${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz.bak"]);
+         exec(["docker", "cp", "/root/.config/gcloud/legacy_credentials/jenkins-deploy@khan-academy.iam.gserviceaccount.com/adc.json", "webapp-datastore-emulator-1:/tmp/adc.json"]);
+         exec(["docker", "exec", "webapp-datastore-emulator-1", "dash", "-c", "gcloud auth activate-service-account --key-file=/tmp/adc.json; gcloud storage cp /var/datastore/dev_datastore.tar.gz ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz"]);
       } finally {
           // No matter what, we stop the local webserver.
          sh("ssh-agent make stop-server");

--- a/jobs/build-current-sqlite.groovy
+++ b/jobs/build-current-sqlite.groovy
@@ -69,7 +69,7 @@ def runScript() {
          // the gcloud service account token since the datastore container
          // does not have access to it by default.
          exec(["gsutil", "cp", "${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz", "${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz.bak"]);
-         exec(["docker", "cp", "/root/.config/gcloud/legacy_credentials/jenkins-deploy@khan-academy.iam.gserviceaccount.com/adc.json", "webapp-datastore-emulator-1:/tmp/adc.json"]);
+         exec(["docker", "cp", "${env.HOME}/.config/gcloud/legacy_credentials/jenkins-deploy@khan-academy.iam.gserviceaccount.com/adc.json", "webapp-datastore-emulator-1:/tmp/adc.json"]);
          exec(["docker", "exec", "webapp-datastore-emulator-1", "dash", "-c", "gcloud auth activate-service-account --key-file=/tmp/adc.json; gcloud storage cp /var/datastore/dev_datastore.tar.gz ${params.CURRENT_SQLITE_BUCKET}/dev_datastore.tar.gz"]);
       } finally {
           // No matter what, we stop the local webserver.


### PR DESCRIPTION
## Summary:
This script broke when I fixed the datastore-emulator container to no
longer mount gcloud credentials, which it doesn't need.  (Actually, as
part of a different security audit, I changed it to mount them
read-only, which made gcloud reject them for some reason.  Then, when
I realized what was going on, I removed the mounting entirely,
realizing it wasn't necessary anymore.)  But it turns out we were
depending on that capability in this script, to copy files from the
container to gcs.

I enable that functionality a different way now.  I manually copy the
credential needed into the countainer, since you can't mount volumes
when running `docker exec` and I wouldn't want to mount the
credentials volume read-write anyway.  And then I use that account to
do the copying, which uses gcloud now instead of gsutil.  And all is
well.

Issue: https://khanacademy.slack.com/archives/C01120CNCS0/p1780329614592999

## Test plan:
I used `replay` to run this new script, at TODO.

Subscribers: @Khan/infra-platform