### PR TITLE
Change second smoke tests to only run prod-only specs

### DIFF
--- a/jobs/e2e-test.groovy
+++ b/jobs/e2e-test.groovy
@@ -191,7 +191,7 @@ def _pullWebapp() {
 // Determines if we are running the first or second smoke test.
 IS_PRODUCTION = (E2E_URL == "https://www.khanacademy.org");
 E2E_RUN_TYPE = IS_PRODUCTION ? "second-smoke-test" : "first-smoke-test";
-E2E_MODE = IS_PRODUCTION ? "production" : "non-default";
+E2E_MODE = IS_PRODUCTION ? "prod-only" : "non-default";
 
 onWorker(WORKER_TYPE, '5h') {     // timeout
    notify([slack: [channel: params.SLACK_CHANNEL,


### PR DESCRIPTION
## Summary:
In order to speed up our webapp deploy queue, use the new option from
https://github.com/Khan/frontend/pull/12456 to run only "prod-only" spec
files. This will yield 2 speed improvements:

1. Second smoke test is currently the long pole for post-set-default
validation. Shortening second smoke duration will reduce this long
pole time.
2. Fewer automated rollbacks due to flaky E2E test failures during
second smoke. This primarily affects unattended deploys.

We believe this is safe as first smoke tests should have caught any
failures before setting default. As a result, the second smoke test only
needs to run the tests that could not be run during first smoke. These
"prod-only" tests are ones that require using prod urls such as
www.khanacademy.org for 3rd party integrations.

Issue: https://khanacademy.atlassian.net/browse/INFRA-11059

## Test plan:
Monitor deployments to verify second smoke is correctly running in the
"prod-only" mode.