### PR TITLE
Log the exact SHAs we expect should_deploy to diff

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -328,8 +328,20 @@ def initializeGlobals() {
          // against the currently live version, and the consequences of doing
          // something else are greater, so we prohibit the dangerous thing.
          if (params.BASE_REVISION) {
+            // Log the exact SHAs we expect should_deploy to generate the git
+            // diff from.
+            from_sha = exec.outputOf(["git", "rev-parse", ${params.BASE_REVISION}])
+            to_sha = exec.outputOf(["git", "rev-parse", "HEAD"])
+            echo("Running should-deploy for the commit range ${from_sha}...${to_sha} ")
+
             shouldDeployArgs += [
                "--commit-range", "${params.BASE_REVISION}...HEAD"]
+         } else {
+            // Log the exact SHAs we expect should_deploy to generate the git
+            // diff from.
+            from_sha = exec.outputOf(["git", "rev-parse", "master"])
+            to_sha = exec.outputOf(["git", "rev-parse", "HEAD"])
+            echo("Running should-deploy for the commit range ${from_sha}...${to_sha} ")
          }
 
          if (params.SERVICES == "auto") {

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -334,6 +334,12 @@ def deploy() {
       dir("webapp") {
          def shouldDeployArgs = ["deploy/should_deploy.py"];
 
+         // Log the exact SHAs we expect should_deploy to generate the git diff
+         // from.
+         from_sha = exec.outputOf(["git", "rev-parse", "master"])
+         to_sha = exec.outputOf(["git", "rev-parse", "HEAD"])
+         echo("Running should-deploy for the commit range ${from_sha}...${to_sha} ")
+
          if (params.SERVICES == "auto") {
             try {
                SERVICES = exec.outputOf(shouldDeployArgs).split("\n");


### PR DESCRIPTION
## Summary:

Because we don't fetch after the initial clone, I don't think there is a
window between when we `git rev-parse master` here and when
`deploy/should_deploy.py` computes the diff where a merge to master may
slip in and change the actual from SHA. Well, at least that's the case if we
aren't using the GH API call from `should_deploy.py`...

We had a deploy that was detected as tools-only that should have
deployed to the progress service.

```sh
06:51:20  + deploy/should_deploy.py
06:51:20  [2026-06-23 06:51:20,080 INFO] Checking for changes in origin/master...HEAD
06:51:38  Deploying to the following services:
06:51:38  Sending list of services for cc738a104c56fbba4d1ed664948fbc6e7f62aef5: tools-only
```

This is particularly odd as, when running the command locally with what
we assume are the same SHAs, a blocking error is encountered.

```sh
$ genfiles/deploy/venv/bin/python deploy/should_deploy.py --commit-range aaf90ce8d2f1c3651d2eb31a4a19f09dd0d82d0a...cc738a104c56fbba4d1ed664948fbc6e7f62aef5 --verbose
[2026-06-23 09:29:42,690 INFO] Checking for changes in aaf90ce8d2f1c3651d2eb31a4a19f09dd0d82d0a...cc738a104c56fbba4d1ed664948fbc6e7f62aef5
[2026-06-23 09:29:42,718 DEBUG] Changed files:
services/progress/entities/problem_log.go
panic: 256:2: expected declaration, found 'if' (and 1 more errors)
	Wrapped by: errors.Wrap: [internal error]
	Wrapped by: go_code_analysis.(*_config).Run: [internal error] Unable to get changed lines for file, filename = services/progress/entities/problem_log.go
```

However, this error is not present in the build-webapp job logs so I am
suspicious of the actual commits that were used to generate the diff.
Let's log the resolved SHAs since deploys at the front of the queue run
without passing explicit SHAs to deploy/should_deploy.py.

Issue: https://khanacademy.atlassian.net/browse/INFRA-11109

Test plan:

1. Run test of build-webapp against this branch with deployable changes.
1. Monitor build-webapp during deployment.
2. Monitor build-webapp after deployment.