### PR TITLE
Pass the new `--is-znd` flag to upload-safelist for znd.s

### DIFF
--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -267,6 +267,7 @@ def uploadGraphqlSafelist() {
          exec([
             "deploy/upload_graphql_safelist.py",
             VERSION,
+            "--is-znd",
             "--prod",
          ])
       }


### PR DESCRIPTION
## Summary:
This is part of a PR series that improves how we do pruning of the
graphql safelist.  The idea is that each graphql-safelist entry,
instead of having just a single value saying when it was last
uploaded, stores its last-upload time on a per-upload-caller basis.
So if a query is used by both frontend and backend code, we know the
last time it was uploaded by the frontend deploy process and the last
time it was uploaded by the backend deploy process.  This matters for
when we prune the safelist; both frontend and backend have their own
formula for when a safelist entry is unused anymore, and we can take
the later of the two.

The reason this matters, and the motivation for doing it, is that when
we upload a query as part of a znd, we don't want to keep it on the
safelist as long as when we upload it for prod.  This PR finishes the
work of distinguishing between znd and non-znd deployers for backend
deploys.

PR series:
* Add the LastUploadByCaller field and znd upload-callers [#40245]
* Update frontend deploys to use the znd upload-caller [Khan/frontend#12861]
* Update backend deploys to use the znd upload-caller [#40396]
* Update jenkins to pass the appropriate flag to the upload script [THIS PR]
* [Wait for a few deploys, until every (non-obsolete) query has
   LastUploadByCaller populated.  If necessary, backfill the rest]
* Change prune.go to respect LastUploadByCaller instead of UploadCallers
* Delete UploadCallers from the model

Issue: https://khanacademy.atlassian.net/browse/INFRA-11099

## Test plan:
Fingers crossed