### PR TITLE
[🔥AUDIT🔥] Fix json parsing in merge-branches

### DIFF
--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -8,7 +8,7 @@
 @Library("kautils")
 // Classes we use, under jenkins-jobs/src/.
 import org.khanacademy.Setup;
-import groovy.json.JsonSlurper;
+import groovy.json.JsonSlurperClassic;
 // Vars we use, under jenkins-jobs/vars/.  This is just for documentation.
 //import vars.buildmaster
 //import vars.exec
@@ -123,7 +123,7 @@ def githubMergeResult(String runId) {
    }
 
    String resultJson = readFile("${resultDir}/merge-branches-result.json");
-   return new JsonSlurper().parseText(resultJson);
+   return new JsonSlurperClassic().parseText(resultJson);
 }
 
 

--- a/vars/runGithubAction.groovy
+++ b/vars/runGithubAction.groovy
@@ -1,5 +1,5 @@
 import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
+import groovy.json.JsonSlurperClassic
 
 def _githubApiHeaders(String token) {
     return [[name: "Authorization",
@@ -48,7 +48,7 @@ def _dispatch(Map args) {
             customHeaders: _githubApiHeaders(args.token),
             httpMode: "GET",
             url: "https://api.github.com/repos/${args.repo}/actions/runs?event=workflow_dispatch&per_page=10${shaFilter}")
-        def runs = new JsonSlurper().parseText(response.content)
+        def runs = new JsonSlurperClassic().parseText(response.content)
         for (run in runs.workflow_runs) {
             if (run.head_branch == args.ref) {
                 runId = run.id.toString()


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
lol groovy, what are you even.

> Root cause: jobs/merge-branches.groovy parsed the downloaded result JSON with `JsonSlurper`, which returns a `LazyMap`. Jenkins CPS can’t serialize that object while pipeline steps are still running. The catch block then reported the buildmaster commit as failed with no SHA, so the success was immediately overwritten by the failure report.

Issue: none

## Test plan:
I did a "replay" with this change, and it worked