### PR TITLE
Disable notify GitHub of commit's webapp-test status

### DIFF
--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -550,9 +550,6 @@ def run(Boolean useGithub) {
                    sender: 'Testing Turtle',
                    emoji: ':turtle:',
                    when: ['FAILURE', 'UNSTABLE']],
-           github: [sha: params.GIT_REVISION,
-                    context: 'webapp-test',
-                    when: ['SUCCESS', 'FAILURE', 'UNSTABLE', 'ABORTED']],
            buildmaster: [sha: params.GIT_REVISION,
                          what: 'webapp-test']]) {
       initializeGlobals();


### PR DESCRIPTION
## Summary:
Our new webapp-test.yml workflow in GitHub Actions has been running
successfully for a couple weeks now. It’s time to switch it to be the
default! This is the first of many steps. The full list can be viewed in
the jira ticket.

Disable the notify call in jenkins webapp-test that adds the jenkin’s
job status to commits in GitHub. Right now we have 2 redundant checks
that appear in PRs: webapp-test from jenkins and webapp-test.yml from
GHA. This will result in the GHA webapp-test.yml checks being the only
checks seen in PRs.

After this is landed and verified, we will disable the webhook for push
events to buildmaster 
(https://github.com/Khan/webapp/settings/hooks/23786240). These 
will no longer be necessary as the PR checks are already triggered by
webapp-test.yml in GHA. Buildmaster will still kick off webapp-test 
jobs in jenkins as needed by the deploy pipeline.

Issue: https://khanacademy.atlassian.net/browse/INFRA-11149

## Test plan:
1. Deploy change.
2. Monitor GitHub PRs to verify check from jenkins does not appear.