### PR TITLE
Match GHA runs by unique dispatch_id instead of head_sha

### DIFF
--- a/jobs/build-webapp.groovy
+++ b/jobs/build-webapp.groovy
@@ -209,9 +209,6 @@ NEW_VERSION = null;
 // This holds the arguments to _alert.  It a groovy struct imported at runtime.
 alertMsgs = null;
 
-// GIT_SHA1 is the sha1 for GIT_REVISION.
-GIT_SHA1 = null;
-
 @NonCPS     // for replaceAll()
 def _interpolateString(def s, def interpolationArgs) {
    // Arguments to replaceAll().  `all` is the entire regexp match,
@@ -580,16 +577,10 @@ def run(Boolean useGithub) {
                          what: 'build-webapp']]) {
 
       if (useGithub) {
-         withTimeout('5m') {
-            GIT_SHA1 = kaGit.resolveCommittish("git@github.com:Khan/webapp",
-                                               params.GIT_REVISION);
-         }
-
          runGithubAction(
             repo: "Khan/webapp",
             workflow: "build-webapp.yml",
             ref: params.GIT_TAG,
-            headSha: GIT_SHA1,
             inputs: [
                git_revision:          params.GIT_REVISION,
                base_revision:         params.BASE_REVISION,

--- a/jobs/delete-version.groovy
+++ b/jobs/delete-version.groovy
@@ -134,13 +134,10 @@ def runInGithub() {
       // coordinates with deploy-webapp while traffic migration remains in
       // Jenkins.
       lock(resource: 'update-traffic-lock', priority: 10) {
-         String masterSha = kaGit.resolveCommittish(
-            "git@github.com:Khan/webapp", "master");
          runGithubAction.dispatchAndWait(
             repo: "Khan/webapp",
             workflow: "delete-versions.yml",
             ref: "master",
-            headSha: masterSha,
             inputs: [
                service_versions: params.SERVICE_VERSIONS,
                dry_run: params.DRY_RUN.toString(),

--- a/jobs/deploy-znd.groovy
+++ b/jobs/deploy-znd.groovy
@@ -414,15 +414,12 @@ def deploy() {
 
 def runInGithub() {
    withTimeout('3h') {
-      def gitSha = kaGit.resolveCommittish("git@github.com:Khan/webapp",
-                                           params.GIT_REVISION);
       // Pass the raw email prefix (untruncated); the workflow handles truncation.
       def actor = wrap([$class: 'BuildUser']) { env.BUILD_USER_ID.split("@")[0] };
       runGithubAction(
          repo: "Khan/webapp",
          workflow: "deploy-znd.yml",
          ref: "master",
-         headSha: gitSha,
          inputs: [
             git_revision: params.GIT_REVISION,
             version: params.VERSION,

--- a/jobs/emergency-rollback.groovy
+++ b/jobs/emergency-rollback.groovy
@@ -151,13 +151,10 @@ def doRollback() {
 
 def doGithubRollback() {
    withTimeout('30m') {
-      def masterSha = kaGit.resolveCommittish("git@github.com:Khan/webapp",
-                                              "master");
       runGithubAction(
          repo: "Khan/webapp",
          workflow: "emergency-rollback.yml",
          ref: "master",
-         headSha: masterSha,
          inputs: [
             dry_run: params.DRY_RUN.toString(),
             rollback_to: params.ROLLBACK_TO,

--- a/jobs/merge-branches.groovy
+++ b/jobs/merge-branches.groovy
@@ -128,13 +128,10 @@ def githubMergeResult(String runId) {
 
 
 def runInGithub() {
-   String masterSha = kaGit.resolveCommittish("git@github.com:Khan/webapp",
-                                             "master");
    String runId = runGithubAction.dispatchAndWait(
       repo: "Khan/webapp",
       workflow: "merge-branches.yml",
       ref: "master",
-      headSha: masterSha,
       inputs: [
          git_revisions: params.GIT_REVISIONS,
          commit_id: params.COMMIT_ID,

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -559,7 +559,6 @@ def run(Boolean useGithub) {
             repo: "Khan/webapp",
             workflow: "webapp-test.yml",
             ref: params.GIT_TAG,
-            headSha: GIT_SHA1,
             inputs: [
                git_revision:          params.GIT_REVISION,
                base_revision:         params.BASE_REVISION,

--- a/vars/runGithubAction.groovy
+++ b/vars/runGithubAction.groovy
@@ -15,14 +15,24 @@ def _githubApiHeaders(String token) {
 //   repo     - GitHub repo, e.g. "Khan/webapp"
 //   workflow - Workflow filename, e.g. "webapp-test.yml"
 //   ref      - Branch name to run the workflow on
-//   headSha  - Resolved SHA for the ref (used to identify the new run)
 //   inputs   - Map of string→string workflow inputs (optional)
 //   token    - a github token, used to perform the workflow_dispatch
 //
-// Dispatches the workflow via the GitHub API, then polls for up to 30s
-// to locate the new run and return its ID.
+// Dispatches the workflow via the GitHub API, tagging the dispatch with a
+// unique dispatch_id input, then polls for up to 30s to locate the new run
+// and return its ID.
 def _dispatch(Map args) {
-    def payload = JsonOutput.toJson([ref: args.ref, inputs: args.inputs ?: [:]])
+    // A unique-per-call ID we can use to unambiguously identify our run once
+    // it's created. workflow_dispatch doesn't return a run ID synchronously,
+    // so we have to poll for it afterward; matching on head_sha/head_branch
+    // alone is ambiguous when a concurrent or still-running prior dispatch
+    // shares the same ref and SHA (e.g. concurrent merge-branches builds
+    // against an unmoved master). The dispatched workflow must template this
+    // into its `run-name:` (which GitHub surfaces as `display_title`) for the
+    // matching below to work.
+    def dispatchId = "${env.BUILD_TAG}-${UUID.randomUUID().toString()}"
+    def inputs = (args.inputs ?: [:]) + [dispatch_id: dispatchId]
+    def payload = JsonOutput.toJson([ref: args.ref, inputs: inputs])
     notify.log("GitHub Actions dispatch payload", [
         level: "INFO",
         repo: args.repo,
@@ -37,20 +47,18 @@ def _dispatch(Map args) {
         requestBody: payload,
         url: "https://api.github.com/repos/${args.repo}/actions/workflows/${args.workflow}/dispatches")
 
-    // Poll for up to 30s (10 attempts × 3s) to find the new run.
-    // Filter by head_sha when available to avoid picking up a concurrent
-    // dispatch against the same branch.
-    def shaFilter = args.headSha ? "&head_sha=${args.headSha}" : ""
+    // Poll for up to 30s (10 attempts × 3s) to find the new run, scoped to
+    // this workflow file and matched by its unique dispatch_id.
     def runId = null
     for (def i = 0; i < 10; i++) {
         sleep(3)
         def response = httpRequest(
             customHeaders: _githubApiHeaders(args.token),
             httpMode: "GET",
-            url: "https://api.github.com/repos/${args.repo}/actions/runs?event=workflow_dispatch&per_page=10${shaFilter}")
+            url: "https://api.github.com/repos/${args.repo}/actions/workflows/${args.workflow}/runs?event=workflow_dispatch&per_page=10")
         def runs = new JsonSlurperClassic().parseText(response.content)
         for (run in runs.workflow_runs) {
-            if (run.head_branch == args.ref) {
+            if (run.display_title == dispatchId) {
                 runId = run.id.toString()
                 break
             }
@@ -85,7 +93,6 @@ def _wait(String repo, String runId, String githubToken) {
 //   repo     - GitHub repo, e.g. "Khan/webapp"
 //   workflow - Workflow filename, e.g. "webapp-test.yml"
 //   ref      - Branch name to run the workflow on
-//   headSha  - Resolved SHA for the ref (used to identify the new run)
 //   inputs   - Map of string→string workflow inputs (optional)
 def call(Map args) {
     dispatchAndWait(args)


### PR DESCRIPTION
## Summary:
workflow_dispatch doesn't return a run ID synchronously, so runGithubAction
has to poll and guess which run is "ours" afterward. Matching on
head_sha + head_branch is ambiguous when a concurrent or still-running
prior dispatch shares the same ref and SHA (e.g. concurrent
merge-branches builds racing against an unmoved master), which caused
Jenkins build 373960 to watch and report success for the wrong run.

Generate a unique dispatch_id per call and send it as a workflow input;
match the polled run by display_title (which GitHub populates from a
run-name: template) instead. This requires the corresponding Khan/webapp
workflows to declare a dispatch_id input and run-name: template before
this lands, since GitHub rejects undeclared workflow_dispatch inputs.

Dependent on https://github.com/Khan/webapp/pull/41171

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Issue: https://khanacademy.atlassian.net/browse/INFRA-11152

Test plan:

As no jobs currently defaults to `USE_GITHUB_BRIDGE=true` at the moment,
it is safe to test each job with `USE_GITHUB_BRIDGE=true` after landing
this.