### PR TITLE
Add ONLY_POST_ON_ERROR to webapp-test, and use it from make-allcheck.

### DIFF
--- a/jobs/make-allcheck.groovy
+++ b/jobs/make-allcheck.groovy
@@ -47,6 +47,9 @@ def runAllTests() {
              string(name: 'NUM_WORKER_MACHINES', value: "6"),
              string(name: 'CLIENTS_PER_WORKER', value: "2"),
              booleanParam(name: 'USE_GITHUB_BRIDGE', value: true),
+             // We don't want to spam the #backend channel every time
+             // the nightly test succeeds like it's supposed to.
+             booleanParam(name: 'ONLY_POST_ON_ERROR', value: true),
           ]);
 }
 

--- a/jobs/webapp-test.groovy
+++ b/jobs/webapp-test.groovy
@@ -63,7 +63,16 @@ If the empty string, run *all* tests.""",
    """The slack thread (must be in SLACK_CHANNEL) to which to send failure
 alerts.  By default we do not send in a thread.  Generally only set by the
 buildmaster, to the 'thread_ts' or 'timestamp' value returned by the Slack
-API.""", ""
+API.""",
+    ""
+
+).addBooleanParam(
+    "ONLY_POST_ON_ERROR",
+    """If true, only post to SLACK_CHANNEL if the tests actually fail.
+(A test exits with FAIL or ERROR, or a test does not run due to a framework
+error of some sort.)  This is intended to be used by the nightly "allcheck"
+run.""",
+    false
 
 ).addChoiceParam(
    "CLEAN",
@@ -565,6 +574,7 @@ def run(Boolean useGithub) {
                base_revision:         params.BASE_REVISION,
                slack_channel:         params.SLACK_CHANNEL,
                slack_thread:          params.SLACK_THREAD,
+               only_post_on_error:    params.ONLY_POST_ON_ERROR,
                deployer_username:     params.DEPLOYER_USERNAME,
                revision_description:  REVISION_DESCRIPTION,
                buildmaster_deploy_id: params.BUILDMASTER_DEPLOY_ID,


### PR DESCRIPTION
## Summary:
Normally, when running the webapp-test github action, we post to slack
with the results.  But there's been a request to not do so in the
(hopefully!) common case that the nightly "allcheck" run passes.  We
only want to see a message if the allcheck run unexpectedly fails.

In Khan/webapp#41541, I added support for a new `--only-post-on-error`
flag in webapp.  In this PR, I wire that thread through to the
make-allcheck job in jenkins.

Issue: https://khanacademy.slack.com/archives/C0A0EP14K/p1786353644754299

## Test plan:
I ran:
```
groovy jobs/make-allcheck.groovy
groovy jobs/webapp-test.groovy
```
to check for typos.  But mostly, fingers crossed!

Subscribers: @Khan/infra-platform